### PR TITLE
for P11 compatibility, remove extension

### DIFF
--- a/src/Foliage-Core/Object.extension.st
+++ b/src/Foliage-Core/Object.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #Object }
-
-{ #category : #'*Foliage-Core' }
-Object >> emit [
-
-	^ self asBeaconSignal emit
-]


### PR DESCRIPTION
this extension cannot be used anymore because `Announcement>>#emit` has been moved to `Object>>#emit`. 
this will break P10 compatibility (but hey... time to move to P11, isn't?)