### PR TITLE
Allow the use of data stored in STON format in a template.

### DIFF
--- a/src/Foliage-Core-Tests/FOPillarPageTest.class.st
+++ b/src/Foliage-Core-Tests/FOPillarPageTest.class.st
@@ -1,0 +1,125 @@
+Class {
+	#name : #FOPillarPageTest,
+	#superclass : #TestCase,
+	#traits : 'FOTTestWebSite',
+	#classTraits : 'FOTTestWebSite classTrait',
+	#instVars : [
+		'fs'
+	],
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #running }
+FOPillarPageTest >> setUp [
+	super setUp.
+
+	self setUpFileSystem.
+	self setUpTemplates.
+	self setUpSources.
+]
+
+{ #category : #templates }
+FOPillarPageTest >> simple [
+
+	^ '<html>
+<title>{{ name }}</title>
+<body>
+{{{ body }}}
+</body>'
+]
+
+{ #category : #sources }
+FOPillarPageTest >> simpleMicrodown [
+
+	^ 'simple.md' -> 
+'---
+title: Simple MD
+layout: simple
+---
+# Simple microdown
+Hello World!'
+]
+
+{ #category : #data }
+FOPillarPageTest >> someData [
+
+	^ '{
+	"site_logo": "images/esug-logo-small.jpg",
+	"name": "ESUG",	
+	"menu" : [
+		{ "title" : "About Us",
+		  "url" : "/about_us.html",
+		  "has_subfiles" : true,
+		  "submenu" : [ { 
+				"title" : "About",
+				"url" : "/about_us.html" 
+				},
+				{ 
+				"title" : "Membership",
+				"url" : "/membership.html" 
+				},
+				{ 
+				"title" : "Become a Sponsor",
+				"url" : "/become_sponsor.html" 
+				}]
+		},
+		{ "title" : "Conferences",
+		  "url" : "/conferences.html",
+		  "has_subfiles" : true,
+		  "submenu" : [ 
+		  		{ 
+				"title" : "2023",
+				"url" : "/2023-Conference/conf2023.html" 
+				},
+		  		{ 
+				"title" : "Past Conferences",
+				"url" : "/conferences.html" 
+				} ]
+		}
+	]
+}'
+ 
+]
+
+{ #category : #tests }
+FOPillarPageTest >> testMustacheTokenIsReplacedByBlankIfNoValueFoundInContext [
+
+	| page htmlString |
+	
+	self setUpWebSite.
+	page := (FOMicrodownReader file: srcDir / 'simple.md') model.
+	page parent: (FOWebsiteRoot new
+			 parent: website;
+			 yourself).
+
+	htmlString := page render.
+
+	self
+		assert: htmlString
+		equals: '<html>
+<title></title>
+<body>
+<h1>Simple microdown</h1><p>Hello World!</p>
+</body>'
+]
+
+{ #category : #tests }
+FOPillarPageTest >> testMustacheTokenIsReplacedIfValueFoundInContext [
+
+	| page htmlString |
+	
+	self setUpWebSite.
+	self setUpWebSiteDataWith: self someData.
+	page := (FOMicrodownReader file: srcDir / 'simple.md') model.
+	page parent: (FOWebsiteRoot new parent: website; yourself).
+	
+	htmlString := page render.
+	
+	self 
+		assert: htmlString 
+		equals: '<html>
+<title>ESUG</title>
+<body>
+<h1>Simple microdown</h1><p>Hello World!</p>
+</body>'
+]

--- a/src/Foliage-Core-Tests/FOTTestWebSite.trait.st
+++ b/src/Foliage-Core-Tests/FOTTestWebSite.trait.st
@@ -1,0 +1,70 @@
+"
+Trait you can use to easily define a web site that will be defined in a memory filesystem and can be used for testing purposes.
+"
+Trait {
+	#name : #FOTTestWebSite,
+	#instVars : [
+		'fs',
+		'srcDir',
+		'outputDir',
+		'templateDir',
+		'foliageConfigurationFile',
+		'website',
+		'dataFile'
+	],
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #running }
+FOTTestWebSite >> setUpFileSystem [
+
+	fs := FileSystem memory.
+	srcDir := fs root / 'src'.
+	srcDir ensureCreateDirectory.
+	outputDir := fs root / 'generated'.
+	foliageConfigurationFile := fs root / '.foliage.ston'.
+]
+
+{ #category : #running }
+FOTTestWebSite >> setUpSources [
+
+	(self class organization protocolNamed: #sources) methodSelectors do: [ :selector | | association |
+		association := self perform: selector.
+		(srcDir / association key) writeStreamDo: [ :stream | 
+			stream nextPutAll: association value ] ]
+
+]
+
+{ #category : #running }
+FOTTestWebSite >> setUpTemplates [
+
+	templateDir := (srcDir / #templates) ensureCreateDirectory.
+	
+	(self class organization protocolNamed: #templates) methodSelectors do: [ :selector | | name |
+		name := (selector endsWith: 'Template')
+			ifTrue: [ selector allButLast: 8  ]
+			ifFalse: [ selector ].
+		(templateDir / name) writeStreamDo: [ :stream | 
+			stream nextPutAll: (self perform: selector) ] ]
+
+]
+
+{ #category : #initialization }
+FOTTestWebSite >> setUpWebSite [
+	
+	self setUpFileSystem.
+	self setUpSources.
+	self setUpTemplates.
+	website := FOWebSite new.
+	website 
+		rawPath: srcDir;
+		templatePath: templateDir.
+]
+
+{ #category : #initialization }
+FOTTestWebSite >> setUpWebSiteDataWith: aDataString [
+	
+	dataFile := fs root / 'data'.
+	dataFile writeStreamDo: [ :stream | stream nextPutAll: aDataString ].
+	website dataPath: dataFile.
+]

--- a/src/Foliage-Core/FOHTMLPage.class.st
+++ b/src/Foliage-Core/FOHTMLPage.class.st
@@ -18,7 +18,7 @@ FOHTMLPage >> acceptFOVisitor: aFOVisitor [
 	^ aFOVisitor visitHTMLPageSource: self 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 FOHTMLPage >> asFOBlogPost [
 	^ self as: FOBlogPost
 ]
@@ -31,7 +31,7 @@ FOHTMLPage >> buildHtmlDocument [
 	^ document
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 FOHTMLPage >> buildHtmlString [
 	htmlDocument ifNotNil: [ 
 		^ htmlDocument printString ].
@@ -44,7 +44,7 @@ FOHTMLPage >> htmlDocument [
 		htmlDocument := self buildHtmlDocument ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FOHTMLPage >> htmlString [
 	^ htmlString ifNil: [ 
 		htmlString := self buildHtmlString ]
@@ -56,7 +56,7 @@ FOHTMLPage >> newRenderContext [
 		page: self 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #converting }
 FOHTMLPage >> render [
 
 	^ nil

--- a/src/Foliage-Core/FOMetaReader.class.st
+++ b/src/Foliage-Core/FOMetaReader.class.st
@@ -39,6 +39,12 @@ FOMetaReader class >> parse: aString [
 	^ self new parse: aString
 ]
 
+{ #category : #parsing }
+FOMetaReader >> hasMetadataHeader [
+
+	^ isYamlMetadataBlock := self isYamlSeparator
+]
+
 { #category : #testing }
 FOMetaReader >> isEndOfMetadataBlock [
 	^ isYamlMetadataBlock 
@@ -93,9 +99,9 @@ FOMetaReader >> readLines [
 	| properties |
 	
 	self readLine.
-	isYamlMetadataBlock := self isYamlSeparator.
-
 	properties := Dictionary new.
+	self hasMetadataHeader ifFalse: [ ^ properties ].
+
 	[ self readLine. stream atEnd or: [ self isEndOfMetadataBlock ] ] whileFalse: [ 
 		| property |
 		property := self propertyFrom: line.

--- a/src/Foliage-Core/FOMetaReader.class.st
+++ b/src/Foliage-Core/FOMetaReader.class.st
@@ -1,8 +1,29 @@
+"
+I'm in charge of reading the Foliage Metadata header and return read properties.
+
+A valid header can be a Yaml metadata block :
+```mardown
+---
+title: Some news
+layout: post
+---
+<html>
+```
+or a list of properties followed by a blanck line:
+```mardown
+title: Some news
+layout: post
+
+<html>
+```
+"
 Class {
 	#name : #FOMetaReader,
 	#superclass : #Object,
 	#instVars : [
-		'stream'
+		'stream',
+		'line',
+		'isYamlMetadataBlock'
 	],
 	#category : #'Foliage-Core-Reader'
 }
@@ -18,23 +39,42 @@ FOMetaReader class >> parse: aString [
 	^ self new parse: aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
+FOMetaReader >> isEndOfMetadataBlock [
+	^ isYamlMetadataBlock 
+		ifTrue: [ self isEndOfYamlMetadataBlock ]
+		ifFalse: [ line isEmpty ]
+]
+
+{ #category : #testing }
+FOMetaReader >> isEndOfYamlMetadataBlock [
+	^ isYamlMetadataBlock and: [ self isYamlSeparator ]
+]
+
+{ #category : #testing }
+FOMetaReader >> isYamlSeparator [
+	^ line trimBoth = '---'
+]
+
+{ #category : #accessing }
 FOMetaReader >> next [
 	^ self readLines 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #parsing }
 FOMetaReader >> parse: aString [ 
 	stream := ZnCharacterReadStream on: aString asByteArray readStream encoding: #utf8.
 	^ self readLines
 ]
 
-{ #category : #'as yet unclassified' }
-FOMetaReader >> readLine [
-	| line parts key vparts |
-	line := stream nextLine.
-	line isEmpty ifTrue: [ ^ nil ].
-	parts := $: split: line.
+{ #category : #converting }
+FOMetaReader >> propertyFrom: aLine [
+	| parts key vparts |
+
+	parts := $: split: aLine.
+	parts size = 1 
+		ifTrue: [ FoMetadataHeaderBadFormat 
+						signal: 'invalid metadata syntax (key: value) or missing metadata separator' ].
 	key := parts first trimBoth.
 	vparts := $; split: parts second.
 	^ key -> ((vparts size = 1) 
@@ -42,19 +82,28 @@ FOMetaReader >> readLine [
 		ifFalse: [ vparts collect: #trimBoth ])
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #parsing }
+FOMetaReader >> readLine [
+
+	line := stream nextLine
+]
+
+{ #category : #parsing }
 FOMetaReader >> readLines [
-	| properties line |
+	| properties |
+	
+	self readLine.
+	isYamlMetadataBlock := self isYamlSeparator.
+
 	properties := Dictionary new.
-	line := ''.
-	[ stream atEnd or: [ line isNil ] ] whileFalse: [ 
-		line := self readLine.
-		line ifNotNil: [
-			properties add: line ]].
+	[ self readLine. stream atEnd or: [ self isEndOfMetadataBlock ] ] whileFalse: [ 
+		| property |
+		property := self propertyFrom: line.
+		property ifNotNil: [ properties add: property ] ].
 	^ properties
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FOMetaReader >> stream: aZnCharacterReadStream [ 
 	stream := aZnCharacterReadStream
 ]

--- a/src/Foliage-Core/FOPageRenderContext.class.st
+++ b/src/Foliage-Core/FOPageRenderContext.class.st
@@ -23,6 +23,13 @@ FOPageRenderContext >> layout [
 	^ page layout
 ]
 
+{ #category : #lookup }
+FOPageRenderContext >> mustacheLookup: aString [
+
+	^ self website data
+		 at: aString ifAbsent: [ super mustacheLookup: aString ]
+]
+
 { #category : #accessing }
 FOPageRenderContext >> page [
 	^ page

--- a/src/Foliage-Core/FOPageRenderContext.class.st
+++ b/src/Foliage-Core/FOPageRenderContext.class.st
@@ -18,7 +18,7 @@ FOPageRenderContext >> html [
 		page renderOn: s ].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FOPageRenderContext >> layout [
 	^ page layout
 ]

--- a/src/Foliage-Core/FOPageWithMetadata.class.st
+++ b/src/Foliage-Core/FOPageWithMetadata.class.st
@@ -87,7 +87,7 @@ FOPageWithMetadata >> publishDate [
 
 { #category : #accessing }
 FOPageWithMetadata >> title [
-	^ self meta at: 'title'
+	^ self meta at: 'title' ifAbsent: ''
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Core/FOPublishVisitor.class.st
+++ b/src/Foliage-Core/FOPublishVisitor.class.st
@@ -7,9 +7,11 @@ Class {
 { #category : #visiting }
 FOPublishVisitor >> copyResource: aResource [ 
 	| target |
+	
 	target := aResource publishPath asFileReference.
 	target exists ifTrue: [  target delete ].
-	aResource sourcePath asFileReference copyTo: target
+	"we need to resolve path when filesystem store is a memory store"
+	(aResource website rawPath parent resolvePath: aResource sourcePath) copyTo: target
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Core/FORenderContext.class.st
+++ b/src/Foliage-Core/FORenderContext.class.st
@@ -7,12 +7,12 @@ Class {
 	#category : #'Foliage-Core-Base'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FORenderContext >> layout [
 	self subclassResponsibility 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 FORenderContext >> partials [ 
 	^ FOPartialProvider new 
 		layout: self layout; 

--- a/src/Foliage-Core/FOWebSite.class.st
+++ b/src/Foliage-Core/FOWebSite.class.st
@@ -16,22 +16,6 @@ Class {
 	#category : #'Foliage-Core-RSS'
 }
 
-{ #category : #'instance creation' }
-FOWebSite class >> build [
-	^ self instance build
-]
-
-{ #category : #'instance creation' }
-FOWebSite class >> instance [
-	^ instance ifNil: [ 
-		instance := self new ]
-]
-
-{ #category : #resetting }
-FOWebSite class >> reset [
-	instance := nil
-]
-
 { #category : #arithmetic }
 FOWebSite >> / anObject [
 	^ root / anObject

--- a/src/Foliage-Core/FOWebSite.class.st
+++ b/src/Foliage-Core/FOWebSite.class.st
@@ -1,3 +1,11 @@
+"
+I represent the web site to generate.
+I hold configuration needed for the generation (pathes, properties, user data) as well as the Root element of the web site that contains all other web site elements.
+
+I'm the entry point of visitors.
+
+You can use the `publish` method to run the publication of the web site.
+"
 Class {
 	#name : #FOWebSite,
 	#superclass : #Object,
@@ -6,14 +14,14 @@ Class {
 		'targetPath',
 		'templatePath',
 		'rawPath',
-		'model',
 		'root',
-		'properties'
+		'properties',
+		'data'
 	],
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'Foliage-Core-RSS'
+	#category : #'Foliage-Core-Model'
 }
 
 { #category : #arithmetic }
@@ -57,6 +65,20 @@ FOWebSite >> buildRoot [
 ]
 
 { #category : #accessing }
+FOWebSite >> data [
+
+	^ data
+]
+
+{ #category : #accessing }
+FOWebSite >> dataPath: aString [
+
+	aString ifNil: [ ^ self ].
+	
+	data := STON fromString: aString asFileReference contents
+]
+
+{ #category : #accessing }
 FOWebSite >> defaultRawPath [
 	^ 'raw'
 ]
@@ -93,7 +115,8 @@ FOWebSite >> importer [
 FOWebSite >> initialize [ 
 	super initialize.
 	properties := Dictionary new.
-	root := self buildRoot 
+	data := Dictionary new: 0.
+	root := self buildRoot
 ]
 
 { #category : #logging }

--- a/src/Foliage-Core/FOWebsiteRoot.class.st
+++ b/src/Foliage-Core/FOWebsiteRoot.class.st
@@ -1,3 +1,7 @@
+"
+I represent the root of the web site.
+I am build from `FOWebSite`.
+"
 Class {
 	#name : #FOWebsiteRoot,
 	#superclass : #FOWebFolder,

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -159,6 +159,16 @@ FOPublisherTest >> testCanPublishFromASimpleMicrodownFileWithYamlMetadataBlock [
 ]
 
 { #category : #tests }
+FOPublisherTest >> testNoWarningRaisedWhenNoFoliageMetadataFound [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | stream nextPutAll: self simpleMicrodownFile ].
+
+	publisher publish.
+	
+	self assert: outputDir fileNames equals: #('index.html').
+]
+
+{ #category : #tests }
 FOPublisherTest >> testWarningRaisedWhenMissingMetadataSeparator [
 
 	(srcDir / 'index.md') writeStreamDo: [ :stream | 
@@ -183,18 +193,6 @@ FOPublisherTest >> testWarningRaisedWhenMissingMetadataSeparatorWithYamlMetadata
 	self 
 		should: [ publisher publish ]
 		raise: FoMetadataHeaderBadFormat
-]
-
-{ #category : #tests }
-FOPublisherTest >> testWarningRaisedWhenNoFoliageMetadataFound [
-
-	(srcDir / 'index.md') writeStreamDo: [ :stream | stream nextPutAll: self simpleMicrodownFile ].
-
-	self 
-		should: [ publisher publish ]
-		raise: FoMetadataHeaderBadFormat.
-
-	
 ]
 
 { #category : #running }

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -4,11 +4,9 @@ A FOPublisherTest is a test class for testing the behavior of FOPublisher
 Class {
 	#name : #FOPublisherTest,
 	#superclass : #TestCase,
+	#traits : 'FOTTestWebSite',
+	#classTraits : 'FOTTestWebSite classTrait',
 	#instVars : [
-		'fs',
-		'outputDir',
-		'srcDir',
-		'foliageConfigurationFile',
 		'publisher'
 	],
 	#category : #'Foliage-Publisher-Tests'
@@ -44,33 +42,14 @@ FOPublisherTest >> pageTemplate [
 FOPublisherTest >> setUp [
 	super setUp.
 
-	fs := FileSystem memory.
-	srcDir := fs / 'src'.
-	srcDir ensureCreateDirectory.
-	outputDir := fs / 'generated'.
-	foliageConfigurationFile := fs / '.foliage.ston'.
-	self useMinimalFoliageConfiguration.
+	self setUpFileSystem.
 	self setUpTemplates.
+	self useMinimalFoliageConfiguration.
 	
 	publisher := FOPublisher readFile: foliageConfigurationFile.
 	publisher 
 		sourcePath: srcDir;
 		targetPath: outputDir.
-]
-
-{ #category : #running }
-FOPublisherTest >> setUpTemplates [
-
-	| templateDir |
-	templateDir := (srcDir / #templates) ensureCreateDirectory.
-	
-	(self class organization protocolNamed: #templates) methodSelectors do: [ :selector | | name |
-		name := (selector endsWith: 'Template')
-			ifTrue: [ selector allButLast: 8  ]
-			ifFalse: [ selector ].
-		(templateDir / name) writeStreamDo: [ :stream | 
-			stream nextPutAll: (self perform: selector) ] ]
-
 ]
 
 { #category : #'tests - input data' }

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -1,0 +1,206 @@
+"
+A FOPublisherTest is a test class for testing the behavior of FOPublisher
+"
+Class {
+	#name : #FOPublisherTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'fs',
+		'outputDir',
+		'srcDir',
+		'foliageConfigurationFile',
+		'publisher'
+	],
+	#category : #'Foliage-Publisher-Tests'
+}
+
+{ #category : #templates }
+FOPublisherTest >> headTemplate [ 
+
+	^ '<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="/files/favicon.ico" />
+</head>'
+]
+
+{ #category : #templates }
+FOPublisherTest >> pageTemplate [ 
+
+	^ '<!DOCTYPE HTML>
+<html>
+    {{> head}}
+    <body class="default">
+        <div id="wrap">
+            <div id="main">
+              {{{body}}}
+            </div>
+        </div>
+    </body>
+</html>'
+]
+
+{ #category : #running }
+FOPublisherTest >> setUp [
+	super setUp.
+
+	fs := FileSystem memory.
+	srcDir := fs / 'src'.
+	srcDir ensureCreateDirectory.
+	outputDir := fs / 'generated'.
+	foliageConfigurationFile := fs / '.foliage.ston'.
+	self useMinimalFoliageConfiguration.
+	self setUpTemplates.
+	
+	publisher := FOPublisher readFile: foliageConfigurationFile.
+	publisher 
+		sourcePath: srcDir;
+		targetPath: outputDir.
+]
+
+{ #category : #running }
+FOPublisherTest >> setUpTemplates [
+
+	| templateDir |
+	templateDir := (srcDir / #templates) ensureCreateDirectory.
+	
+	(self class organization protocolNamed: #templates) methodSelectors do: [ :selector | | name |
+		name := (selector endsWith: 'Template')
+			ifTrue: [ selector allButLast: 8  ]
+			ifFalse: [ selector ].
+		(templateDir / name) writeStreamDo: [ :stream | 
+			stream nextPutAll: (self perform: selector) ] ]
+
+]
+
+{ #category : #'tests - input data' }
+FOPublisherTest >> simpleMicrodownFile [
+
+	^ String streamContents: [ :str |
+		str 
+			nextPutAll: '# Header 1'; cr;
+			nextPutAll: '## Header 2'; cr;
+			cr;
+			nextPutAll: '- item A'; cr;
+			nextPutAll: '- item B'; cr;
+			nextPutAll: '- item C'; cr;
+			nextPutAll: '# Another header 1'; cr;
+			nextPutAll: 'Some paragraph with [a link](https://w3c.org).'; cr
+	]
+]
+
+{ #category : #'tests - input data' }
+FOPublisherTest >> simpleMicrodownFileWithMetaData [
+
+	^ String streamContents: [ :str |
+		str 
+			nextPutAll: 'title: A simple md'; cr; cr;
+			nextPutAll: self simpleMicrodownFile
+	]
+]
+
+{ #category : #tests }
+FOPublisherTest >> testCanPublishFromASimpleMicrodownFile [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | stream nextPutAll: self simpleMicrodownFileWithMetaData ].
+
+	publisher publish.
+	
+	self assertCollection: outputDir fileNames equals: #( 'index.html' ).
+	self 
+		assert: (outputDir / 'index.html') contents
+		equals: '<!DOCTYPE HTML>
+<html>
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="/files/favicon.ico" />
+</head>
+    <body class="default">
+        <div id="wrap">
+            <div id="main">
+              <h1>Header 1</h1><h2>Header 2</h2><ul><li>item A</li><li>item B</li><li>item C</li></ul><h1>Another header 1</h1><p>Some paragraph with <a href="https://w3c.org">a link</a>.</p>
+            </div>
+        </div>
+    </body>
+</html>'
+]
+
+{ #category : #tests }
+FOPublisherTest >> testCanPublishFromASimpleMicrodownFileWithYamlMetadataBlock [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | 
+		stream 
+			nextPutAll: '---'; cr;
+			nextPutAll: 'title: Page with Yaml metadata block'; cr;
+			nextPutAll: '---'; cr;
+			nextPutAll: self simpleMicrodownFile ].
+
+	publisher publish.
+	
+	self assertCollection: outputDir fileNames equals: #( 'index.html' ).
+	self 
+		assert: (outputDir / 'index.html') contents
+		equals: '<!DOCTYPE HTML>
+<html>
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="/files/favicon.ico" />
+</head>
+    <body class="default">
+        <div id="wrap">
+            <div id="main">
+              <h1>Header 1</h1><h2>Header 2</h2><ul><li>item A</li><li>item B</li><li>item C</li></ul><h1>Another header 1</h1><p>Some paragraph with <a href="https://w3c.org">a link</a>.</p>
+            </div>
+        </div>
+    </body>
+</html>'
+]
+
+{ #category : #tests }
+FOPublisherTest >> testWarningRaisedWhenMissingMetadataSeparator [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | 
+		stream 
+			nextPutAll: 'title: A simple md'; cr;
+			nextPutAll: self simpleMicrodownFile ].
+
+	self 
+		should: [ publisher publish ]
+		raise: FoMetadataHeaderBadFormat
+]
+
+{ #category : #tests }
+FOPublisherTest >> testWarningRaisedWhenMissingMetadataSeparatorWithYamlMetadataBlock [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | 
+		stream 
+			nextPutAll: '---'; cr;
+			nextPutAll: 'title: A simple md'; cr;
+			nextPutAll: self simpleMicrodownFile ].
+
+	self 
+		should: [ publisher publish ]
+		raise: FoMetadataHeaderBadFormat
+]
+
+{ #category : #tests }
+FOPublisherTest >> testWarningRaisedWhenNoFoliageMetadataFound [
+
+	(srcDir / 'index.md') writeStreamDo: [ :stream | stream nextPutAll: self simpleMicrodownFile ].
+
+	self 
+		should: [ publisher publish ]
+		raise: FoMetadataHeaderBadFormat.
+
+	
+]
+
+{ #category : #running }
+FOPublisherTest >> useMinimalFoliageConfiguration [
+	foliageConfigurationFile writeStreamDo: [ : stream |
+		stream nextPutAll: 'Foliage {
+	#baseUri: ''/''
+}' ]
+]

--- a/src/Foliage-Publisher-Tests/package.st
+++ b/src/Foliage-Publisher-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Foliage-Publisher-Tests' }

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -10,7 +10,8 @@ Class {
 		'targetPath',
 		'sourcePath',
 		'templatePath',
-		'blogs'
+		'blogs',
+		'dataPath'
 	],
 	#category : #'Foliage-Publisher'
 }
@@ -151,6 +152,18 @@ FOPublisher >> blogs: anObject [
 	blogs := anObject
 ]
 
+{ #category : #accessing }
+FOPublisher >> dataPath [
+
+	^ dataPath
+]
+
+{ #category : #accessing }
+FOPublisher >> dataPath: aString [
+
+	dataPath := aString
+]
+
 { #category : #actions }
 FOPublisher >> publish [
 	| site allFiles |
@@ -161,7 +174,8 @@ FOPublisher >> publish [
 		baseUri: self baseUri;
 		targetPath: self targetPath asFileReference;
 		rawPath: self sourcePath asFileReference;
-		templatePath: self sourcePath asFileReference / self templatePath.
+		templatePath: self sourcePath asFileReference / self templatePath;
+		dataPath: self dataPath.
 	
 	site emit.
 

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -1,3 +1,7 @@
+"
+I'm the entry point to generate a static web site.
+I first read a Foliage configuration file (e.g. `.foliage.ston`) and I can then generate the web site to the specified target path from sources present in the specified source path using the `FOPublisher>>#publish` method.
+"
 Class {
 	#name : #FOPublisher,
 	#superclass : #Object,
@@ -138,7 +142,7 @@ FOPublisher >> baseUri: aString [
 { #category : #accessing }
 FOPublisher >> blogs [
 
-	^ blogs
+	^ blogs ifNil: [ #() ]
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Publisher/FoMetadataHeaderBadFormat.class.st
+++ b/src/Foliage-Publisher/FoMetadataHeaderBadFormat.class.st
@@ -1,0 +1,28 @@
+"
+Error raised when a malformed Foliage metadata header is found!
+
+A valid metadata header must contains:
+- one or many lines with the format: `key: value`
+- followed by a blank line acting as a separator for the header
+example:
+```
+title: my title
+author: my name
+date: today
+
+```
+
+We prefer to use the yaml metadata block syntax that is also supported:
+```
+---
+title: my title
+author: my name
+date: today
+---
+```
+"
+Class {
+	#name : #FoMetadataHeaderBadFormat,
+	#superclass : #Error,
+	#category : #'Foliage-Publisher'
+}


### PR DESCRIPTION
It is useful, for example, to build a menu by using mustache sections facilities.
Also define a trait to reuse data setup for testing