### PR TITLE
ensure blogs answer a collection and not nil

### DIFF
--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -138,7 +138,7 @@ FOPublisher >> baseUri: aString [
 { #category : #accessing }
 FOPublisher >> blogs [
 
-	^ blogs
+	^ blogs ifNil: [ #() ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
because we rely on it later :P
(otherwise, if you do not declare it explicitly in the foliage configuration, we will get a DNU)