### PR TITLE
Add fenced and indented code blocks

### DIFF
--- a/src/Foliage-Markdown-Tests/FOHTMLRenderVisitorTest.class.st
+++ b/src/Foliage-Markdown-Tests/FOHTMLRenderVisitorTest.class.st
@@ -37,3 +37,27 @@ FOHTMLRenderVisitorTest >> testRenderDocumentJoinsChildrenWithNewline [
 	html := FOHTMLRenderVisitor render: doc.
 	self assert: html equals: '<h1>Title</h1>', self nl, '<p>Body text.</p>'
 ]
+
+{ #category : #tests }
+FOHTMLRenderVisitorTest >> testRenderCodeBlockWithLanguage [
+	| html block |
+	block := FOCodeBlock new kind: #fenced; language: 'smalltalk'; code: 'foo bar'; yourself.
+	html := FOHTMLRenderVisitor render: block.
+	self assert: html equals: '<pre><code class="language-smalltalk">foo bar</code></pre>'
+]
+
+{ #category : #tests }
+FOHTMLRenderVisitorTest >> testRenderCodeBlockWithoutLanguage [
+	| html block |
+	block := FOCodeBlock new kind: #indented; language: nil; code: 'foo bar'; yourself.
+	html := FOHTMLRenderVisitor render: block.
+	self assert: html equals: '<pre><code>foo bar</code></pre>'
+]
+
+{ #category : #tests }
+FOHTMLRenderVisitorTest >> testRenderCodeBlockEscapesHtml [
+	| html block |
+	block := FOCodeBlock new kind: #fenced; language: 'html'; code: '<div>&x</div>'; yourself.
+	html := FOHTMLRenderVisitor render: block.
+	self assert: html equals: '<pre><code class="language-html">&lt;div&gt;&amp;x&lt;/div&gt;</code></pre>'
+]

--- a/src/Foliage-Markdown-Tests/FOMarkdownBlockParserTest.class.st
+++ b/src/Foliage-Markdown-Tests/FOMarkdownBlockParserTest.class.st
@@ -66,3 +66,73 @@ FOMarkdownBlockParserTest >> testMultipleParagraphsSeparatedByBlankLine [
 	self assert: doc children first text equals: 'first paragraph'.
 	self assert: doc children second text equals: 'second paragraph'
 ]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testFencedCodeWithLanguage [
+	| doc block |
+	doc := FOMarkdownParser parse: '```language=smalltalk', self nl, 'foo bar', self nl, '```'.
+	self assert: doc children size equals: 1.
+	block := doc children first.
+	self assert: (block isKindOf: FOCodeBlock).
+	self assert: block kind equals: #fenced.
+	self assert: block language equals: 'smalltalk'.
+	self assert: block code equals: 'foo bar'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testFencedCodeWithoutLanguage [
+	| doc block |
+	doc := FOMarkdownParser parse: '```', self nl, 'plain code', self nl, '```'.
+	block := doc children first.
+	self assert: block kind equals: #fenced.
+	self assert: block language isNil.
+	self assert: block code equals: 'plain code'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testFencedCodeLenientAboutMismatchedFenceLength [
+	"Real content (2020-11-07_blog-navigation.md) opens with 4 backticks and closes with 3."
+	| doc block |
+	doc := FOMarkdownParser parse: '````language=html', self nl, '<div></div>', self nl, '```'.
+	block := doc children first.
+	self assert: block kind equals: #fenced.
+	self assert: block language equals: 'html'.
+	self assert: block code equals: '<div></div>'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testFencedCodeMultipleLines [
+	| doc block |
+	doc := FOMarkdownParser parse: '```', self nl, 'line one', self nl, 'line two', self nl, '```'.
+	block := doc children first.
+	self assert: block code equals: 'line one', self nl, 'line two'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testUnterminatedFencedCodeDoesNotCrash [
+	| doc block |
+	doc := FOMarkdownParser parse: '```language=smalltalk', self nl, 'no closing fence'.
+	block := doc children first.
+	self assert: block code equals: 'no closing fence'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testIndentedCode [
+	| doc block |
+	doc := FOMarkdownParser parse: '    fun no fun', self nl, '    no more fun'.
+	block := doc children first.
+	self assert: (block isKindOf: FOCodeBlock).
+	self assert: block kind equals: #indented.
+	self assert: block language isNil.
+	self assert: block code equals: 'fun no fun', self nl, 'no more fun'
+]
+
+{ #category : #tests }
+FOMarkdownBlockParserTest >> testCodeBlockThenParagraph [
+	| doc |
+	doc := FOMarkdownParser parse: '```', self nl, 'code', self nl, '```', self nl, self nl, 'after'.
+	self assert: doc children size equals: 2.
+	self assert: (doc children first isKindOf: FOCodeBlock).
+	self assert: (doc children second isKindOf: FOParagraph).
+	self assert: doc children second text equals: 'after'
+]

--- a/src/Foliage-Markdown/FOCodeBlock.class.st
+++ b/src/Foliage-Markdown/FOCodeBlock.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #FOCodeBlock,
+	#superclass : #FOBlockNode,
+	#instVars : [
+		'code',
+		'language',
+		'kind'
+	],
+	#category : #'Foliage-Markdown'
+}
+
+{ #category : #accessing }
+FOCodeBlock >> code [
+	^ code
+]
+
+{ #category : #accessing }
+FOCodeBlock >> code: aString [
+	code := aString
+]
+
+{ #category : #accessing }
+FOCodeBlock >> language [
+	^ language
+]
+
+{ #category : #accessing }
+FOCodeBlock >> language: aStringOrNil [
+	language := aStringOrNil
+]
+
+{ #category : #accessing }
+FOCodeBlock >> kind [
+	^ kind
+]
+
+{ #category : #accessing }
+FOCodeBlock >> kind: aSymbol [
+	kind := aSymbol
+]
+
+{ #category : #visiting }
+FOCodeBlock >> acceptVisitor: aVisitor [
+	^ aVisitor visitCodeBlock: self
+]

--- a/src/Foliage-Markdown/FOHTMLRenderVisitor.class.st
+++ b/src/Foliage-Markdown/FOHTMLRenderVisitor.class.st
@@ -29,6 +29,15 @@ FOHTMLRenderVisitor >> visitParagraph: aParagraph [
 	^ '<p>', (self escapeHtml: aParagraph text), '</p>'
 ]
 
+{ #category : #visiting }
+FOHTMLRenderVisitor >> visitCodeBlock: aCodeBlock [
+	| classAttr |
+	classAttr := aCodeBlock language
+		ifNil: [ '' ]
+		ifNotNil: [ :lang | ' class="language-', lang, '"' ].
+	^ '<pre><code', classAttr, '>', (self escapeHtml: aCodeBlock code), '</code></pre>'
+]
+
 { #category : #private }
 FOHTMLRenderVisitor >> escapeHtml: aString [
 	| result |

--- a/src/Foliage-Markdown/FOMarkdownParser.class.st
+++ b/src/Foliage-Markdown/FOMarkdownParser.class.st
@@ -11,18 +11,23 @@ FOMarkdownParser class >> parse: aString [
 
 { #category : #parsing }
 FOMarkdownParser >> parse: aString [
-	| reader document classification |
+	| reader document classification block |
 	reader := FOLineReader on: aString.
 	document := FODocument new.
 	[ reader atEnd ] whileFalse: [
 		classification := FOLineClassifier classify: reader peek.
-		classification kind = #blank
-			ifTrue: [ reader next ]
-			ifFalse: [
-				classification kind = #atxHeader
-					ifTrue: [ document addChild: (self consumeHeader: reader classification: classification) ]
-					ifFalse: [ document addChild: (self consumeParagraph: reader) ] ] ].
+		block := self consumeBlock: reader classification: classification.
+		block ifNotNil: [ document addChild: block ] ].
 	^ document
+]
+
+{ #category : #private }
+FOMarkdownParser >> consumeBlock: aReader classification: aClassification [
+	aClassification kind = #blank ifTrue: [ aReader next. ^ nil ].
+	aClassification kind = #atxHeader ifTrue: [ ^ self consumeHeader: aReader classification: aClassification ].
+	aClassification kind = #fenceDelimiter ifTrue: [ ^ self consumeFencedCode: aReader classification: aClassification ].
+	aClassification kind = #indentedCode ifTrue: [ ^ self consumeIndentedCode: aReader ].
+	^ self consumeParagraph: aReader
 ]
 
 { #category : #private }
@@ -39,9 +44,39 @@ FOMarkdownParser >> consumeParagraph: aReader [
 	lines := OrderedCollection new.
 	[ aReader atEnd not and: [
 		classification := FOLineClassifier classify: aReader peek.
-		classification kind ~= #blank and: [ classification kind ~= #atxHeader ] ] ]
+		(#(#blank #atxHeader #fenceDelimiter #indentedCode) includes: classification kind) not ] ]
 		whileTrue: [ lines add: aReader next trimBoth ].
 	^ FOParagraph new text: (self joinWithSpace: lines); yourself
+]
+
+{ #category : #private }
+FOMarkdownParser >> consumeFencedCode: aReader classification: aClassification [
+	| lines |
+	aReader next.
+	lines := OrderedCollection new.
+	[ aReader atEnd not and: [ (FOLineClassifier classify: aReader peek) kind ~= #fenceDelimiter ] ]
+		whileTrue: [ lines add: aReader next ].
+	aReader atEnd ifFalse: [ aReader next ].
+	^ FOCodeBlock new
+		kind: #fenced;
+		language: aClassification language;
+		code: (self joinWithNewline: lines);
+		yourself
+]
+
+{ #category : #private }
+FOMarkdownParser >> consumeIndentedCode: aReader [
+	| lines line |
+	lines := OrderedCollection new.
+	[ aReader atEnd not and: [ (FOLineClassifier classify: aReader peek) kind = #indentedCode ] ]
+		whileTrue: [
+			line := aReader next.
+			lines add: (aReader stripIndent: 4 from: line) ].
+	^ FOCodeBlock new
+		kind: #indented;
+		language: nil;
+		code: (self joinWithNewline: lines);
+		yourself
 ]
 
 { #category : #private }
@@ -50,4 +85,12 @@ FOMarkdownParser >> joinWithSpace: aCollection [
 		aCollection
 			do: [ :l | s nextPutAll: l ]
 			separatedBy: [ s nextPut: $  ] ]
+]
+
+{ #category : #private }
+FOMarkdownParser >> joinWithNewline: aCollection [
+	^ String streamContents: [ :s |
+		aCollection
+			do: [ :l | s nextPutAll: l ]
+			separatedBy: [ s nextPut: Character lf ] ]
 ]

--- a/src/Foliage-Markdown/FOVisitor.class.st
+++ b/src/Foliage-Markdown/FOVisitor.class.st
@@ -18,3 +18,8 @@ FOVisitor >> visitHeader: aHeader [
 FOVisitor >> visitParagraph: aParagraph [
 	^ self subclassResponsibility
 ]
+
+{ #category : #visiting }
+FOVisitor >> visitCodeBlock: aCodeBlock [
+	^ self subclassResponsibility
+]


### PR DESCRIPTION
FOCodeBlock captures verbatim code, an optional language (parsed from the custom `language=xxx` fence annotation, not standard ```lang), and which form it came from (#fenced vs #indented). Fenced blocks are lenient about fence length (any run of >=3 backticks opens/closes one, no exact-length matching), confirmed necessary by a real post that opens a 4-backtick fence and closes it with 3. An unterminated fence at EOF degrades gracefully (keeps whatever was captured) instead of erroring.

FOHTMLRenderVisitor renders fenced-with-language as <pre><code class="language-xxx">, everything else as plain <pre><code>, HTML-escaping the code content.

consumeParagraph: now also stops at #fenceDelimiter/#indentedCode lines (previously only #blank/#atxHeader), narrowing the "everything else is a paragraph" fallback from step 4 now that code blocks have their own branch. Spot-checked against 2020-11-07_blog-navigation.md, which exercises the mismatched-fence-length case for real.