### PR TITLE
Paginate the blog overview page (10 posts per page)

### DIFF
--- a/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
@@ -75,3 +75,39 @@ FOBlogOverviewBuilderTest >> testOverviewPagePublishesCorrectly [
 	self assert: publishedFile exists.
 	self assert: publishedFile contents equals: '<html><title>My Blog</title><article>January text.</article></html>'
 ]
+
+{ #category : #tests }
+FOBlogOverviewBuilderTest >> testFewerPostsThanPageSizeYieldsOnePageWithNoMoreLink [
+	blog at: #jan put: (self makePostTitled: 'Jan post' publishDate: '2020-01-01' text: 'January text.').
+	blog at: #feb put: (self makePostTitled: 'Feb post' publishDate: '2020-02-01' text: 'February text.').
+	self assert: blog overviewPages size equals: 1.
+	self assert: (blog overviewPage htmlString includesSubstring: 'more') not
+]
+
+{ #category : #tests }
+FOBlogOverviewBuilderTest >> testPaginationSplitsPostsAcrossPagesNewestFirst [
+	"5 posts, page size 2 (set below default 10 so the test doesn't need 11
+	posts to exercise pagination) -> pages of [mar,feb] [jan,dec] [nov]."
+	| builder pages |
+	blog at: #jan put: (self makePostTitled: 'Jan post' publishDate: '2020-01-01' text: 'Jan text.').
+	blog at: #feb put: (self makePostTitled: 'Feb post' publishDate: '2020-02-01' text: 'Feb text.').
+	blog at: #mar put: (self makePostTitled: 'Mar post' publishDate: '2020-03-01' text: 'Mar text.').
+	blog at: #dec put: (self makePostTitled: 'Dec post' publishDate: '2019-12-01' text: 'Dec text.').
+	blog at: #nov put: (self makePostTitled: 'Nov post' publishDate: '2019-11-01' text: 'Nov text.').
+	builder := FOBlogOverviewBuilder new blog: blog; pageSize: 2; yourself.
+	pages := builder buildPages.
+	self assert: pages size equals: 3.
+	self assert: (pages first htmlString includesSubstring: '<article>Mar text.</article><article>Feb text.</article>').
+	self assert: (pages first htmlString includesSubstring: 'href="page2.html">more</a>').
+	self assert: (pages second htmlString includesSubstring: '<article>Jan text.</article><article>Dec text.</article>').
+	self assert: (pages second htmlString includesSubstring: 'href="page3.html">more</a>').
+	self assert: (pages third htmlString includesSubstring: '<article>Nov text.</article>').
+	self assert: (pages third htmlString includesSubstring: 'more') not
+]
+
+{ #category : #tests }
+FOBlogOverviewBuilderTest >> testPageFilenames [
+	self assert: (FOBlogOverviewBuilder pageFilenameFor: 1) equals: #'index.html'.
+	self assert: (FOBlogOverviewBuilder pageFilenameFor: 2) equals: #'page2.html'.
+	self assert: (FOBlogOverviewBuilder pageFilenameFor: 3) equals: #'page3.html'
+]

--- a/src/Foliage-Core/FOBlog.class.st
+++ b/src/Foliage-Core/FOBlog.class.st
@@ -48,9 +48,17 @@ FOBlog >> layout: aString [
 
 { #category : #accessing }
 FOBlog >> overviewPage [
+	"The first page of the paginated overview - kept as a single-page
+	accessor since most callers (and all callers before pagination existed)
+	only need the blog's own index.html; see overviewPages for the full set."
+	^ self overviewPages first
+]
+
+{ #category : #accessing }
+FOBlog >> overviewPages [
 	^ FOBlogOverviewBuilder new
 		blog: self;
-		buildSummary
+		buildPages
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Core/FOBlogOverviewBuilder.class.st
+++ b/src/Foliage-Core/FOBlogOverviewBuilder.class.st
@@ -2,26 +2,70 @@ Class {
 	#name : #FOBlogOverviewBuilder,
 	#superclass : #Object,
 	#instVars : [
-		'blog'
+		'blog',
+		'pageSize'
 	],
 	#category : #'Foliage-Core-Blog'
 }
+
+{ #category : #'file names' }
+FOBlogOverviewBuilder class >> pageFilenameFor: aPageNumber [
+	"Page 1 is always the blog's own index.html (and, via FOPublisher/build
+	scripts, typically also mirrored as the site's root index.html) - every
+	later page is a flat pageN.html sibling, consistent with this site's
+	existing flat .html-per-resource convention (no nested page/N/ folders)."
+	^ aPageNumber = 1
+		ifTrue: [ #'index.html' ]
+		ifFalse: [ ('page', aPageNumber printString, '.html') asSymbol ]
+]
 
 { #category : #accessing }
 FOBlogOverviewBuilder >> blog: aBlog [
 	blog := aBlog
 ]
 
+{ #category : #accessing }
+FOBlogOverviewBuilder >> defaultPageSize [
+	^ 10
+]
+
+{ #category : #accessing }
+FOBlogOverviewBuilder >> pageSize [
+	^ pageSize ifNil: [ self defaultPageSize ]
+]
+
+{ #category : #accessing }
+FOBlogOverviewBuilder >> pageSize: anInteger [
+	pageSize := anInteger
+]
+
 { #category : #building }
-FOBlogOverviewBuilder >> buildSummary [
+FOBlogOverviewBuilder >> buildPages [
+	"One page per pageSize-sized slice of publishedPosts, newest-first
+	(matches sorting already used before pagination existed). Zero posts
+	still yields exactly one (empty) page, same as the pre-pagination
+	behavior of always producing a valid overview page."
+	| posts pageCount |
+	posts := self publishedPosts.
+	pageCount := (posts size / self pageSize) ceiling max: 1.
+	^ (1 to: pageCount) collect: [ :i |
+		self
+			buildPageIndex: i
+			ofTotal: pageCount
+			posts: posts ]
+]
+
+{ #category : #building }
+FOBlogOverviewBuilder >> buildPageIndex: aPageNumber ofTotal: aPageCount posts: allPosts [
 	"No Pillar wrapper (the old code built a fake PRDocument/PRRaw tree just to
 	push pre-rendered HTML through the same Pillar pipeline - that's what its
 	'#todo: how to organize layouts for in-memory pages??' was about). Instead:
 	an FOFoliagePage with metadata, its bodyHtml set directly to the
-	concatenation of each post's independently-rendered abstract. This still
-	goes through the normal #render/#template pipeline (the blog's own outer
-	layout, {{page.title}}, partials, ...) since #renderOn: uses bodyHtml only
-	for the body slot, not to bypass templating altogether.
+	concatenation of each post's independently-rendered abstract (plus a
+	trailing 'more' link to the next page, if any). This still goes through
+	the normal #render/#template pipeline (the blog's own outer layout,
+	{{page.title}}, partials, ...) since #renderOn: uses bodyHtml only for
+	the body slot, not to bypass templating altogether.
 
 	Must be an FOFoliagePage specifically, not a plain FOPageWithMetadata: the
 	publish visitor dispatches on acceptFOVisitor:, and FOPageWithMetadata
@@ -29,15 +73,27 @@ FOBlogOverviewBuilder >> buildSummary [
 	file to copy from sourcePath, which this synthetic page doesn't have) -
 	FOFoliagePage dispatches to visitFoliagePage: (calls #publish), which is
 	what a page built from in-memory content actually needs."
-	| html |
+	| start stop pagePosts html |
+	start := (aPageNumber - 1) * self pageSize + 1.
+	stop := (aPageNumber * self pageSize) min: allPosts size.
+	pagePosts := start <= allPosts size
+		ifTrue: [ allPosts copyFrom: start to: stop ]
+		ifFalse: [ #() ].
 	html := String streamContents: [ :s |
-		self publishedPosts do: [ :post | s nextPutAll: post renderAbstract ] ].
+		pagePosts do: [ :post | s nextPutAll: post renderAbstract ].
+		aPageNumber < aPageCount ifTrue: [
+			s nextPutAll: (self moreLinkHtmlFor: aPageNumber + 1) ] ].
 	^ FOFoliagePage new
 		parent: blog parent;
 		title: blog title;
 		layout: blog layout;
 		bodyHtml: html;
 		yourself
+]
+
+{ #category : #building }
+FOBlogOverviewBuilder >> moreLinkHtmlFor: aNextPageNumber [
+	^ '<p><a href="', (self class pageFilenameFor: aNextPageNumber), '">more</a></p>'
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -56,6 +56,27 @@ FOPublisherTest >> testPublishGeneratesPostOverviewAndFeed [
 ]
 
 { #category : #tests }
+FOPublisherTest >> testPublishPaginatesOverviewPastDefaultPageSizeOfTen [
+	"jan.md (from setUp) plus 10 more posts = 11 published posts total,
+	one more than the default page size of 10 - should split into
+	index.html (10 newest) + page2.html (1 oldest, with a 'more' link
+	from index.html pointing to it)."
+	1 to: 10 do: [ :n |
+		(tempDir / 'source' / 'blog' / ('post', n printString, '.md')) writeStreamDo: [ :s |
+			s nextPutAll: 'title: Post ', n printString, String lf,
+				'layout: blog-post', String lf,
+				'publishDate: 2020-02-', (n + 10) printString, String lf,
+				String lf,
+				'Post ', n printString, ' text.' ] ].
+	publisher publish.
+	self assert: (tempDir / 'generated' / 'blog' / 'index.html') exists.
+	self assert: (tempDir / 'generated' / 'blog' / 'page2.html') exists.
+	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'href="page2.html">more</a>').
+	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'January text.') not.
+	self assert: ((tempDir / 'generated' / 'blog' / 'page2.html') contents includesSubstring: 'January text.')
+]
+
+{ #category : #tests }
 FOPublisherTest >> testDefaults [
 	| fresh |
 	fresh := FOPublisher new.

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -89,9 +89,9 @@ FOPublisher >> publish [
 		| blog |
 		blog := site / assoc key.
 		blog title: assoc value.
-		blog
-			at: #'index.html' put: blog overviewPage;
-			at: #'rss.xml' put: blog rssFeed ].
+		blog overviewPages doWithIndex: [ :page :i |
+			blog at: (FOBlogOverviewBuilder pageFilenameFor: i) put: page ].
+		blog at: #'rss.xml' put: blog rssFeed ].
 	site publish
 ]
 


### PR DESCRIPTION
FOBlogOverviewBuilder previously concatenated every published post's abstract onto a single page, growing without bound as more posts get added. Now splits into pages of 10 (newest-first, unchanged sort), each page ending with a "more" link to the next one (last page has none).

FOBlog>>overviewPage now returns just the first page (kept for backward compatibility - the only thing every prior caller needed); the new overviewPages returns the full ordered list. FOPublisher>>publish inserts each page under its own filename (index.html, page2.html, page3.html, ... via the new FOBlogOverviewBuilder class>>pageFilenameFor:) instead of a single index.html.

Page size (10) is a plain instance-overridable default on the builder for now, not wired through FOPublisher/STON - no one asked for per-site configuration yet, and it's a one-line addition later if needed.

Verified against the real noha.github.io content (15 posts): index.html gets the newest 10 with a link to page2.html, page2.html gets the remaining 5 with no further link.