### PR TITLE
Fix "more" link to use an absolute (blog-rooted) path

### DIFF
--- a/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
@@ -98,9 +98,9 @@ FOBlogOverviewBuilderTest >> testPaginationSplitsPostsAcrossPagesNewestFirst [
 	pages := builder buildPages.
 	self assert: pages size equals: 3.
 	self assert: (pages first htmlString includesSubstring: '<article>Mar text.</article><article>Feb text.</article>').
-	self assert: (pages first htmlString includesSubstring: 'href="page2.html">more</a>').
+	self assert: (pages first htmlString includesSubstring: 'href="/blog/page2.html">more</a>').
 	self assert: (pages second htmlString includesSubstring: '<article>Jan text.</article><article>Dec text.</article>').
-	self assert: (pages second htmlString includesSubstring: 'href="page3.html">more</a>').
+	self assert: (pages second htmlString includesSubstring: 'href="/blog/page3.html">more</a>').
 	self assert: (pages third htmlString includesSubstring: '<article>Nov text.</article>').
 	self assert: (pages third htmlString includesSubstring: 'more') not
 ]

--- a/src/Foliage-Core/FOBlogOverviewBuilder.class.st
+++ b/src/Foliage-Core/FOBlogOverviewBuilder.class.st
@@ -93,7 +93,12 @@ FOBlogOverviewBuilder >> buildPageIndex: aPageNumber ofTotal: aPageCount posts: 
 
 { #category : #building }
 FOBlogOverviewBuilder >> moreLinkHtmlFor: aNextPageNumber [
-	^ '<p><a href="', (self class pageFilenameFor: aNextPageNumber), '">more</a></p>'
+	"Absolute (blog-rooted) path, not a bare relative filename: the same
+	rendered page content is reused verbatim as both blog/pageN.html AND -
+	in this site's own build script - the site's root index.html, where a
+	relative 'page2.html' would wrongly resolve to /page2.html instead of
+	/blog/page2.html."
+	^ '<p><a href="', blog pathString, '/', (self class pageFilenameFor: aNextPageNumber), '">more</a></p>'
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -71,7 +71,7 @@ FOPublisherTest >> testPublishPaginatesOverviewPastDefaultPageSizeOfTen [
 	publisher publish.
 	self assert: (tempDir / 'generated' / 'blog' / 'index.html') exists.
 	self assert: (tempDir / 'generated' / 'blog' / 'page2.html') exists.
-	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'href="page2.html">more</a>').
+	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'href="/blog/page2.html">more</a>').
 	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'January text.') not.
 	self assert: ((tempDir / 'generated' / 'blog' / 'page2.html') contents includesSubstring: 'January text.')
 ]


### PR DESCRIPTION
FOBlogOverviewBuilder>>moreLinkHtmlFor: used a bare relative filename (href="page2.html"). That only resolves correctly when the page is actually served at /blog/index.html - but noha.github.io's build.st reuses the exact same rendered overview page content verbatim as the site's own root index.html too, where a relative page2.html wrongly resolves to /page2.html instead of /blog/page2.html.

Fixed to build an absolute path from the blog's own pathString (/blog/page2.html). Updated the two tests that asserted on the link's href to match.