### PR TITLE
Add "newer"/"older" navigation to every paginated overview page

### DIFF
--- a/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogOverviewBuilderTest.class.st
@@ -77,17 +77,21 @@ FOBlogOverviewBuilderTest >> testOverviewPagePublishesCorrectly [
 ]
 
 { #category : #tests }
-FOBlogOverviewBuilderTest >> testFewerPostsThanPageSizeYieldsOnePageWithNoMoreLink [
+FOBlogOverviewBuilderTest >> testFewerPostsThanPageSizeYieldsOnePageWithNoNavigationLinks [
 	blog at: #jan put: (self makePostTitled: 'Jan post' publishDate: '2020-01-01' text: 'January text.').
 	blog at: #feb put: (self makePostTitled: 'Feb post' publishDate: '2020-02-01' text: 'February text.').
 	self assert: blog overviewPages size equals: 1.
-	self assert: (blog overviewPage htmlString includesSubstring: 'more') not
+	self assert: (blog overviewPage htmlString includesSubstring: 'older') not.
+	self assert: (blog overviewPage htmlString includesSubstring: 'newer') not
 ]
 
 { #category : #tests }
 FOBlogOverviewBuilderTest >> testPaginationSplitsPostsAcrossPagesNewestFirst [
 	"5 posts, page size 2 (set below default 10 so the test doesn't need 11
-	posts to exercise pagination) -> pages of [mar,feb] [jan,dec] [nov]."
+	posts to exercise pagination) -> pages of [mar,feb] [jan,dec] [nov].
+	First page: only 'older' (nothing is newer than the newest page). Last
+	page: only 'newer' (nothing is older than the oldest page). Middle
+	page: both."
 	| builder pages |
 	blog at: #jan put: (self makePostTitled: 'Jan post' publishDate: '2020-01-01' text: 'Jan text.').
 	blog at: #feb put: (self makePostTitled: 'Feb post' publishDate: '2020-02-01' text: 'Feb text.').
@@ -97,12 +101,18 @@ FOBlogOverviewBuilderTest >> testPaginationSplitsPostsAcrossPagesNewestFirst [
 	builder := FOBlogOverviewBuilder new blog: blog; pageSize: 2; yourself.
 	pages := builder buildPages.
 	self assert: pages size equals: 3.
+
 	self assert: (pages first htmlString includesSubstring: '<article>Mar text.</article><article>Feb text.</article>').
-	self assert: (pages first htmlString includesSubstring: 'href="/blog/page2.html">more</a>').
+	self assert: (pages first htmlString includesSubstring: 'href="/blog/page2.html">older</a>').
+	self assert: (pages first htmlString includesSubstring: 'newer') not.
+
 	self assert: (pages second htmlString includesSubstring: '<article>Jan text.</article><article>Dec text.</article>').
-	self assert: (pages second htmlString includesSubstring: 'href="/blog/page3.html">more</a>').
+	self assert: (pages second htmlString includesSubstring: 'href="/blog/index.html">newer</a>').
+	self assert: (pages second htmlString includesSubstring: 'href="/blog/page3.html">older</a>').
+
 	self assert: (pages third htmlString includesSubstring: '<article>Nov text.</article>').
-	self assert: (pages third htmlString includesSubstring: 'more') not
+	self assert: (pages third htmlString includesSubstring: 'href="/blog/page2.html">newer</a>').
+	self assert: (pages third htmlString includesSubstring: 'older') not
 ]
 
 { #category : #tests }

--- a/src/Foliage-Core/FOBlogOverviewBuilder.class.st
+++ b/src/Foliage-Core/FOBlogOverviewBuilder.class.st
@@ -81,8 +81,7 @@ FOBlogOverviewBuilder >> buildPageIndex: aPageNumber ofTotal: aPageCount posts: 
 		ifFalse: [ #() ].
 	html := String streamContents: [ :s |
 		pagePosts do: [ :post | s nextPutAll: post renderAbstract ].
-		aPageNumber < aPageCount ifTrue: [
-			s nextPutAll: (self moreLinkHtmlFor: aPageNumber + 1) ] ].
+		s nextPutAll: (self navigationHtmlForPageIndex: aPageNumber ofTotal: aPageCount) ].
 	^ FOFoliagePage new
 		parent: blog parent;
 		title: blog title;
@@ -92,13 +91,24 @@ FOBlogOverviewBuilder >> buildPageIndex: aPageNumber ofTotal: aPageCount posts: 
 ]
 
 { #category : #building }
-FOBlogOverviewBuilder >> moreLinkHtmlFor: aNextPageNumber [
-	"Absolute (blog-rooted) path, not a bare relative filename: the same
-	rendered page content is reused verbatim as both blog/pageN.html AND -
-	in this site's own build script - the site's root index.html, where a
-	relative 'page2.html' would wrongly resolve to /page2.html instead of
-	/blog/page2.html."
-	^ '<p><a href="', blog pathString, '/', (self class pageFilenameFor: aNextPageNumber), '">more</a></p>'
+FOBlogOverviewBuilder >> navigationHtmlForPageIndex: aPageNumber ofTotal: aPageCount [
+	"Older posts live on later pages (higher page numbers), newer posts on
+	earlier ones - mirrors the blog-post template's own previousPost (older,
+	left)/nextPost (newer, right) convention, so 'older' is only shown when
+	a later page exists and 'newer' only when an earlier one does: page 1
+	gets only 'older', the last page gets only 'newer', pages in between get
+	both. Absolute (blog-rooted) paths for the same reason as
+	pageFilenameFor: callers elsewhere: this same rendered body is reused
+	verbatim as the site's root index.html too, where a relative filename
+	would resolve wrong."
+	| links |
+	links := OrderedCollection new.
+	aPageNumber < aPageCount ifTrue: [
+		links add: '<a href="', blog pathString, '/', (self class pageFilenameFor: aPageNumber + 1), '">older</a>' ].
+	aPageNumber > 1 ifTrue: [
+		links add: '<a href="', blog pathString, '/', (self class pageFilenameFor: aPageNumber - 1), '">newer</a>' ].
+	links isEmpty ifTrue: [ ^ '' ].
+	^ '<p>', (String streamContents: [ :s | links do: [ :l | s nextPutAll: l ] separatedBy: [ s nextPutAll: ' ' ] ]), '</p>'
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -59,8 +59,9 @@ FOPublisherTest >> testPublishGeneratesPostOverviewAndFeed [
 FOPublisherTest >> testPublishPaginatesOverviewPastDefaultPageSizeOfTen [
 	"jan.md (from setUp) plus 10 more posts = 11 published posts total,
 	one more than the default page size of 10 - should split into
-	index.html (10 newest) + page2.html (1 oldest, with a 'more' link
-	from index.html pointing to it)."
+	index.html (10 newest, 'older' link to page2) + page2.html (1 oldest,
+	'newer' link back to index.html, no 'older' link since it's the last
+	page)."
 	1 to: 10 do: [ :n |
 		(tempDir / 'source' / 'blog' / ('post', n printString, '.md')) writeStreamDo: [ :s |
 			s nextPutAll: 'title: Post ', n printString, String lf,
@@ -71,8 +72,11 @@ FOPublisherTest >> testPublishPaginatesOverviewPastDefaultPageSizeOfTen [
 	publisher publish.
 	self assert: (tempDir / 'generated' / 'blog' / 'index.html') exists.
 	self assert: (tempDir / 'generated' / 'blog' / 'page2.html') exists.
-	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'href="/blog/page2.html">more</a>').
+	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'href="/blog/page2.html">older</a>').
+	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'newer') not.
 	self assert: ((tempDir / 'generated' / 'blog' / 'index.html') contents includesSubstring: 'January text.') not.
+	self assert: ((tempDir / 'generated' / 'blog' / 'page2.html') contents includesSubstring: 'href="/blog/index.html">newer</a>').
+	self assert: ((tempDir / 'generated' / 'blog' / 'page2.html') contents includesSubstring: 'older') not.
 	self assert: ((tempDir / 'generated' / 'blog' / 'page2.html') contents includesSubstring: 'January text.')
 ]
 


### PR DESCRIPTION
Previously only a single "more" link (page 1 -> page 2) existed; pages past the first had no way back and no way further. Replaced with proper bidirectional navigation, mirroring the blog-post template's own previousPost (older)/nextPost (newer) convention:

- page 1: only "older" (nothing is newer than the newest page)
- last page: only "newer" (nothing is older than the oldest page)
- pages in between: both

Verified against the real noha.github.io content (15 posts, 2 pages): blog/index.html has "older" -> /blog/page2.html only, blog/page2.html has "newer" -> /blog/index.html only.