### PR TITLE
Add blog post series (roadmap lean-rollout steps 1+2)

### DIFF
--- a/src/Foliage-Core-Tests/FOBlogPostRenderContextTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogPostRenderContextTest.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : #FOBlogPostRenderContextTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'blog'
+	],
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #running }
+FOBlogPostRenderContextTest >> setUp [
+	super setUp.
+	blog := FOBlog new title: 'My Blog'; yourself.
+	FOWebSite new root at: #blog put: blog
+]
+
+{ #category : #private }
+FOBlogPostRenderContextTest >> makePostTitled: aTitle publishDate: aDateString series: aSlug [
+	| post |
+	post := FOFoliagePage new
+		meta: (Dictionary new
+			at: #title put: aTitle;
+			at: #publishDate put: aDateString;
+			yourself);
+		document: (FOMarkdownParser parse: aTitle, ' text.');
+		yourself.
+	aSlug ifNotNil: [ post meta at: #series put: aSlug ].
+	^ post
+]
+
+{ #category : #private }
+FOBlogPostRenderContextTest >> contextFor: aFOBlogPost [
+	^ FOBlogPostRenderContext new page: aFOBlogPost; yourself
+]
+
+{ #category : #tests }
+FOBlogPostRenderContextTest >> testHasSeriesIsFalseWhenPostHasNoSeries [
+	blog at: #solo put: (self makePostTitled: 'Solo' publishDate: '2020-01-01' series: nil).
+	self deny: (self contextFor: (blog / #solo)) hasSeries
+]
+
+{ #category : #tests }
+FOBlogPostRenderContextTest >> testSeriesNavigationAndTitleForMiddlePart [
+	| part1 part2 part3 context |
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-21' series: 'soil').
+	blog at: #part3 put: (self makePostTitled: 'Part 3' publishDate: '2026-07-22' series: 'soil').
+	part1 := blog / #part1.
+	part2 := blog / #part2.
+	part3 := blog / #part3.
+	context := self contextFor: part2.
+	self assert: context hasSeries.
+	self assert: context seriesTitle equals: 'Soil'.
+	self assert: context seriesPartNumber equals: 2.
+	self assert: context seriesPartCount equals: 3.
+	self assert: context seriesOverviewPath equals: '/blog/series/soil.html'.
+	self assert: context seriesPreviousPost equals: part1.
+	self assert: context seriesNextPost equals: part3
+]
+
+{ #category : #tests }
+FOBlogPostRenderContextTest >> testSeriesNavigationHasNoPreviousOnFirstPartOrNextOnLastPart [
+	| part1 part2 |
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-21' series: 'soil').
+	part1 := blog / #part1.
+	part2 := blog / #part2.
+	self assert: (self contextFor: part1) seriesPreviousPost isNil.
+	self assert: (self contextFor: part2) seriesNextPost isNil
+]

--- a/src/Foliage-Core-Tests/FOBlogTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogTest.class.st
@@ -18,6 +18,14 @@ FOBlogTest >> makePostTitled: aTitle publishDate: aDateString [
 		yourself
 ]
 
+{ #category : #private }
+FOBlogTest >> makePostTitled: aTitle publishDate: aDateString series: aSlug [
+	| post |
+	post := self makePostTitled: aTitle publishDate: aDateString.
+	post meta at: #series put: aSlug.
+	^ post
+]
+
 { #category : #running }
 FOBlogTest >> setUp [
 	super setUp.
@@ -87,4 +95,40 @@ FOBlogTest >> testBlogPathsCreatesAFOBlogDuringImport [
 	resolved := site resolvePath: (RelativePath from: 'blog').
 	self assert: (resolved isKindOf: FOBlog).
 	self assert: (site resolvePath: (RelativePath from: 'other')) class equals: FOWebFolder
+]
+
+{ #category : #tests }
+FOBlogTest >> testPostsInSeriesReturnsOnlyMatchingPostsOldestFirst [
+	"Reading order (ascending), not the blog's own newest-first browsing
+	order - and inserted out of date order to prove it's actually sorted,
+	not just insertion order."
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-22' series: 'soil').
+	blog at: #unrelated put: (self makePostTitled: 'Unrelated' publishDate: '2026-07-21').
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	self assert: ((blog postsInSeries: 'soil') collect: #title) asArray equals: #('Part 1' 'Part 2')
+]
+
+{ #category : #tests }
+FOBlogTest >> testSeriesSlugsAndSeriesCollectionSortedAlphabetically [
+	blog at: #a put: (self makePostTitled: 'Soil A' publishDate: '2026-07-20' series: 'soil').
+	blog at: #b put: (self makePostTitled: 'Byob A' publishDate: '2023-01-07' series: 'byob').
+	blog at: #c put: (self makePostTitled: 'No series' publishDate: '2020-01-01').
+	self assert: blog seriesSlugs equals: #('soil' 'byob') asSet.
+	self assert: (blog series collect: #slug) asArray equals: #('byob' 'soil').
+	self assert: (blog series first title) equals: 'Byob'.
+	self assert: (blog series first posts size) equals: 1
+]
+
+{ #category : #tests }
+FOBlogTest >> testSeriesPostAfterAndBeforeIgnoreUnrelatedPosts [
+	| part1 part2 |
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	blog at: #unrelated put: (self makePostTitled: 'Unrelated' publishDate: '2026-07-21').
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-22' series: 'soil').
+	part1 := blog / #part1.
+	part2 := blog / #part2.
+	self assert: (blog seriesPostAfter: part1) equals: part2.
+	self assert: (blog seriesPostBefore: part2) equals: part1.
+	self assert: (blog seriesPostAfter: part2) isNil.
+	self assert: (blog seriesPostBefore: part1) isNil
 ]

--- a/src/Foliage-Core-Tests/FOSeriesOverviewBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOSeriesOverviewBuilderTest.class.st
@@ -1,0 +1,66 @@
+Class {
+	#name : #FOSeriesOverviewBuilderTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'tempDir',
+		'site',
+		'blog'
+	],
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #running }
+FOSeriesOverviewBuilderTest >> setUp [
+	super setUp.
+	tempDir := FileLocator temp / ('fo-series-overview-test-', UUID new asString36).
+	tempDir ensureCreateDirectory.
+	(tempDir / 'templates') ensureCreateDirectory.
+	(tempDir / 'templates' / 'blog') writeStreamDo: [ :s |
+		s nextPutAll: '<html><title>{{page.title}}</title>{{{ body }}}</html>' ].
+	(tempDir / 'templates' / 'blog-post-abstract') writeStreamDo: [ :s |
+		s nextPutAll: '<article>{{abstract}}</article>' ].
+	(tempDir / 'templates' / 'blog-post') writeStreamDo: [ :s |
+		s nextPutAll: '<html><title>{{page.title}}</title>{{{ body }}}</html>' ].
+	site := FOWebSite new
+		targetPath: (tempDir / 'docs');
+		templatePath: (tempDir / 'templates');
+		yourself.
+	blog := FOBlog new title: 'My Blog'; yourself.
+	site root at: #blog put: blog
+]
+
+{ #category : #running }
+FOSeriesOverviewBuilderTest >> tearDown [
+	tempDir ifNotNil: [ tempDir exists ifTrue: [ tempDir deleteAll ] ].
+	super tearDown
+]
+
+{ #category : #private }
+FOSeriesOverviewBuilderTest >> makePostTitled: aTitle publishDate: aDateString series: aSlug [
+	| post |
+	post := FOFoliagePage new
+		meta: (Dictionary new
+			at: #title put: aTitle;
+			at: #publishDate put: aDateString;
+			yourself);
+		document: (FOMarkdownParser parse: aTitle, ' text.');
+		yourself.
+	post meta at: #series put: aSlug.
+	^ post
+]
+
+{ #category : #tests }
+FOSeriesOverviewBuilderTest >> testBuildPageContainsOnlyThatSeriesAbstractsOldestFirst [
+	| builder aSeries page stream |
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-22' series: 'soil').
+	blog at: #unrelated put: (self makePostTitled: 'Unrelated' publishDate: '2026-07-21' series: 'other').
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	aSeries := blog series detect: [ :s | s slug = 'soil' ].
+	builder := FOSeriesOverviewBuilder new blog: blog; series: aSeries; yourself.
+	page := builder buildPage.
+	self assert: page title equals: 'Soil'.
+	stream := WriteStream on: String new.
+	page renderOn: stream.
+	self assert: stream contents equals:
+		'<article>Part 1 text.</article><article>Part 2 text.</article>'
+]

--- a/src/Foliage-Core-Tests/FOSeriesTest.class.st
+++ b/src/Foliage-Core-Tests/FOSeriesTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : #FOSeriesTest,
+	#superclass : #TestCase,
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #tests }
+FOSeriesTest >> testTitleFromSlugCapitalizesEachHyphenatedWord [
+	self assert: (FOSeries titleFromSlug: 'soil') equals: 'Soil'.
+	self assert: (FOSeries titleFromSlug: 'byob-database') equals: 'Byob Database'
+]
+
+{ #category : #tests }
+FOSeriesTest >> testTitleFromSlugHandlesSingleLetterWords [
+	self assert: (FOSeries titleFromSlug: 'a-b') equals: 'A B'
+]
+
+{ #category : #tests }
+FOSeriesTest >> testTitleDelegatesToClassSideTitleFromSlug [
+	| series |
+	series := FOSeries new slug: 'soil'; yourself.
+	self assert: series title equals: 'Soil'
+]

--- a/src/Foliage-Core/FOBlog.class.st
+++ b/src/Foliage-Core/FOBlog.class.st
@@ -91,6 +91,49 @@ FOBlog >> publishedPosts [
 	^ self posts select: #isPublished
 ]
 
+{ #category : #series }
+FOBlog >> series [
+	"One FOSeries per distinct 'series' slug found among published posts,
+	alphabetically by slug for deterministic output ordering."
+	^ self seriesSlugs asSortedCollection asArray collect: [ :slug |
+		FOSeries new
+			slug: slug;
+			posts: (self postsInSeries: slug);
+			yourself ]
+]
+
+{ #category : #series }
+FOBlog >> seriesSlugs [
+	^ ((self publishedPosts select: #hasSeries) collect: #series) asSet
+]
+
+{ #category : #series }
+FOBlog >> postsInSeries: aSlug [
+	"Reading order (oldest/part-1 first) - a series is meant to be read in
+	sequence, unlike the blog overview's newest-first browsing order."
+	^ (self publishedPosts select: [ :post | post series = aSlug ]) sorted: #publishDate ascending
+]
+
+{ #category : #series }
+FOBlog >> seriesPostAfter: aFOBlogPost [
+	| list index |
+	list := self postsInSeries: aFOBlogPost series.
+	index := list indexOf: aFOBlogPost.
+	^ (index < list size)
+		ifTrue: [ list at: index + 1 ]
+		ifFalse: [ nil ]
+]
+
+{ #category : #series }
+FOBlog >> seriesPostBefore: aFOBlogPost [
+	| list index |
+	list := self postsInSeries: aFOBlogPost series.
+	index := list indexOf: aFOBlogPost.
+	^ (index > 1)
+		ifTrue: [ list at: index - 1 ]
+		ifFalse: [ nil ]
+]
+
 { #category : #accessing }
 FOBlog >> buildRssFeed [
 	^ (FORSSVisitor new visit: self)

--- a/src/Foliage-Core/FOBlogPost.class.st
+++ b/src/Foliage-Core/FOBlogPost.class.st
@@ -49,6 +49,11 @@ FOBlogPost >> defaultLayout [
 ]
 
 { #category : #testing }
+FOBlogPost >> hasSeries [
+	^ self series notNil
+]
+
+{ #category : #testing }
 FOBlogPost >> isPost [
 	^ true
 ]
@@ -56,6 +61,13 @@ FOBlogPost >> isPost [
 { #category : #accessing }
 FOBlogPost >> renderAbstract [
 	^ self newRenderContext renderTemplate: self abstractTemplate
+]
+
+{ #category : #accessing }
+FOBlogPost >> series [
+	"The frontmatter 'series: <slug>' key, e.g. 'series: soil' - a post
+	belongs to at most one series; absent means it isn't part of one."
+	^ self meta at: #series ifAbsent: [ nil ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Foliage-Core/FOBlogPostRenderContext.class.st
+++ b/src/Foliage-Core/FOBlogPostRenderContext.class.st
@@ -23,3 +23,38 @@ FOBlogPostRenderContext >> pathString [
 FOBlogPostRenderContext >> previousPost [
 	^ page parent postBefore: self page
 ]
+
+{ #category : #series }
+FOBlogPostRenderContext >> hasSeries [
+	^ self page hasSeries
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesTitle [
+	^ FOSeries titleFromSlug: self page series
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesPartNumber [
+	^ (page parent postsInSeries: self page series) indexOf: self page
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesPartCount [
+	^ (page parent postsInSeries: self page series) size
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesOverviewPath [
+	^ page parent pathString, '/series/', self page series, '.html'
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesPreviousPost [
+	^ page parent seriesPostBefore: self page
+]
+
+{ #category : #series }
+FOBlogPostRenderContext >> seriesNextPost [
+	^ page parent seriesPostAfter: self page
+]

--- a/src/Foliage-Core/FOSeries.class.st
+++ b/src/Foliage-Core/FOSeries.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : #FOSeries,
+	#superclass : #Object,
+	#instVars : [
+		'slug',
+		'posts'
+	],
+	#category : #'Foliage-Core-Blog'
+}
+
+{ #category : #'instance creation' }
+FOSeries class >> titleFromSlug: aSlug [
+	"'soil' -> 'Soil', 'byob-database' -> 'Byob Database'. A zero-config
+	stand-in for a real display title, per the lean-rollout decision to defer
+	a slug->title registry until one is actually needed."
+	^ String streamContents: [ :s |
+		(aSlug substrings: '-') do: [ :word |
+			s nextPutAll: word first asUppercase asString.
+			word size > 1 ifTrue: [ s nextPutAll: (word copyFrom: 2 to: word size) ] ]
+		separatedBy: [ s nextPut: $  ] ]
+]
+
+{ #category : #accessing }
+FOSeries >> posts [
+	^ posts
+]
+
+{ #category : #accessing }
+FOSeries >> posts: aCollection [
+	posts := aCollection
+]
+
+{ #category : #accessing }
+FOSeries >> slug [
+	^ slug
+]
+
+{ #category : #accessing }
+FOSeries >> slug: aString [
+	slug := aString
+]
+
+{ #category : #accessing }
+FOSeries >> title [
+	^ self class titleFromSlug: slug
+]

--- a/src/Foliage-Core/FOSeriesOverviewBuilder.class.st
+++ b/src/Foliage-Core/FOSeriesOverviewBuilder.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #FOSeriesOverviewBuilder,
+	#superclass : #Object,
+	#instVars : [
+		'blog',
+		'series'
+	],
+	#category : #'Foliage-Core-Blog'
+}
+
+{ #category : #accessing }
+FOSeriesOverviewBuilder >> blog: aBlog [
+	blog := aBlog
+]
+
+{ #category : #accessing }
+FOSeriesOverviewBuilder >> series: aFOSeries [
+	series := aFOSeries
+]
+
+{ #category : #building }
+FOSeriesOverviewBuilder >> buildPage [
+	"Same approach as FOBlogOverviewBuilder (bodyHtml set directly to the
+	concatenation of each post's rendered abstract, still going through the
+	normal outer #render/#template pipeline) - no pagination here, series are
+	expected to be short enough that all parts fit on one page."
+	| html |
+	html := String streamContents: [ :s |
+		series posts do: [ :post | s nextPutAll: post renderAbstract ] ].
+	^ FOFoliagePage new
+		parent: blog parent;
+		title: series title;
+		layout: blog layout;
+		bodyHtml: html;
+		yourself
+]

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -81,6 +81,39 @@ FOPublisherTest >> testPublishPaginatesOverviewPastDefaultPageSizeOfTen [
 ]
 
 { #category : #tests }
+FOPublisherTest >> testPublishGeneratesSeriesOverviewPage [
+	| html |
+	(tempDir / 'source' / 'blog' / 'soil1.md') writeStreamDo: [ :s |
+		s nextPutAll: 'title: Soil part 1', String lf,
+			'layout: blog-post', String lf,
+			'publishDate: 2026-07-20', String lf,
+			'series: soil', String lf,
+			String lf,
+			'Soil part 1 text.' ].
+	(tempDir / 'source' / 'blog' / 'soil2.md') writeStreamDo: [ :s |
+		s nextPutAll: 'title: Soil part 2', String lf,
+			'layout: blog-post', String lf,
+			'publishDate: 2026-07-21', String lf,
+			'series: soil', String lf,
+			String lf,
+			'Soil part 2 text.' ].
+	publisher publish.
+	self assert: (tempDir / 'generated' / 'blog' / 'series' / 'soil.html') exists.
+	html := (tempDir / 'generated' / 'blog' / 'series' / 'soil.html') contents.
+	self assert: (html includesSubstring: '<title>Soil</title>').
+	self assert: (html includesSubstring: 'Soil part 1 text.').
+	self assert: (html includesSubstring: 'Soil part 2 text.').
+	self assert: (html indexOfSubCollection: 'Soil part 1 text.') <
+		(html indexOfSubCollection: 'Soil part 2 text.')
+]
+
+{ #category : #tests }
+FOPublisherTest >> testPublishCreatesNoSeriesFolderWhenNoPostHasASeries [
+	publisher publish.
+	self deny: (tempDir / 'generated' / 'blog' / 'series') exists
+]
+
+{ #category : #tests }
 FOPublisherTest >> testDefaults [
 	| fresh |
 	fresh := FOPublisher new.

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -86,12 +86,18 @@ FOPublisher >> publish [
 	allFiles := site rawPath allFiles.
 	site importer readAll: allFiles.
 	self blogs do: [ :assoc |
-		| blog |
+		| blog seriesFolder |
 		blog := site / assoc key.
 		blog title: assoc value.
 		blog overviewPages doWithIndex: [ :page :i |
 			blog at: (FOBlogOverviewBuilder pageFilenameFor: i) put: page ].
-		blog at: #'rss.xml' put: blog rssFeed ].
+		blog at: #'rss.xml' put: blog rssFeed.
+		blog series ifNotEmpty: [
+			seriesFolder := blog resolvePath: (RelativePath from: 'series').
+			blog series do: [ :aSeries |
+				seriesFolder
+					at: (aSeries slug, '.html') asSymbol
+					put: (FOSeriesOverviewBuilder new blog: blog; series: aSeries; buildPage) ] ] ].
 	site publish
 ]
 


### PR DESCRIPTION
Implements the "Serien (series)" section of Foliage Roadmap.md: posts can declare series: <slug> in frontmatter to belong to an ordered, finite sequence with its own overview page and inline navigation - distinct from a tag, which is unordered membership only.

New:
- FOBlogPost>>series/hasSeries reads the frontmatter key.
- FOSeries: slug + posts (a series' own reading-order post list), title derived from the slug (e.g. 'soil' -> 'Soil', 'byob-database' -> 'Byob Database') - a zero-config stand-in for a real title registry, deferred per the roadmap's lean-rollout ordering until actually needed.
- FOBlog>>series/seriesSlugs/postsInSeries:/seriesPostAfter:/ seriesPostBefore: - same grouping/sorting mechanics as the existing publishedPosts/postAfter:/postBefore:, filtered to a series and sorted ascending (reading order), not the blog's own newest-first browsing order.
- FOSeriesOverviewBuilder: same bodyHtml/abstract-concatenation approach as FOBlogOverviewBuilder, no pagination (series are expected to be short).
- FOBlogPostRenderContext: hasSeries/seriesTitle/seriesPartNumber/ seriesPartCount/seriesOverviewPath/seriesPreviousPost/seriesNextPost, for a template's inline "part N of M" nav.
- FOPublisher>>publish now also builds one page per series under blog/series/<slug>.html, alongside the existing overview pages and feed.

Deliberately not included (per the roadmap's own lean-rollout ordering, "step 3, if needed"): seriesPart frontmatter override for reading order, a slug->title registry, RSS per series.

Verified against real content: tagged the two real Soil posts with series: soil in a scratch copy and ran the full publish pipeline - blog/series/soil.html lists both abstracts in reading order (part 1 before part 2), and each post's rendered page (via the noha.github.io template's own new inline-nav section, done as a companion change in that repo) shows correct part-number/prev/next/overview-link output.