### PR TITLE
Add a series index page listing all series with abstracts

### DIFF
--- a/src/Foliage-Core-Tests/FOBlogTest.class.st
+++ b/src/Foliage-Core-Tests/FOBlogTest.class.st
@@ -109,14 +109,25 @@ FOBlogTest >> testPostsInSeriesReturnsOnlyMatchingPostsOldestFirst [
 ]
 
 { #category : #tests }
-FOBlogTest >> testSeriesSlugsAndSeriesCollectionSortedAlphabetically [
+FOBlogTest >> testSeriesSlugsAndSeriesCollection [
 	blog at: #a put: (self makePostTitled: 'Soil A' publishDate: '2026-07-20' series: 'soil').
 	blog at: #b put: (self makePostTitled: 'Byob A' publishDate: '2023-01-07' series: 'byob').
 	blog at: #c put: (self makePostTitled: 'No series' publishDate: '2020-01-01').
 	self assert: blog seriesSlugs equals: #('soil' 'byob') asSet.
-	self assert: (blog series collect: #slug) asArray equals: #('byob' 'soil').
-	self assert: (blog series first title) equals: 'Byob'.
+	self assert: (blog series collect: #slug) asArray equals: #('soil' 'byob').
+	self assert: (blog series first title) equals: 'Soil'.
 	self assert: (blog series first posts size) equals: 1
+]
+
+{ #category : #tests }
+FOBlogTest >> testSeriesAreSortedByTheirMostRecentPostDescending [
+	"'byob' has an older first post but a NEWER last post than 'soil' -
+	proves the sort looks at each series' most recent (last) post, not its
+	first one or its slug."
+	blog at: #byobOld put: (self makePostTitled: 'Byob old' publishDate: '2020-01-01' series: 'byob').
+	blog at: #byobNew put: (self makePostTitled: 'Byob new' publishDate: '2026-07-01' series: 'byob').
+	blog at: #soil put: (self makePostTitled: 'Soil only' publishDate: '2023-06-01' series: 'soil').
+	self assert: (blog series collect: #slug) asArray equals: #('byob' 'soil')
 ]
 
 { #category : #tests }

--- a/src/Foliage-Core-Tests/FOSeriesIndexBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOSeriesIndexBuilderTest.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #FOSeriesIndexBuilderTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'tempDir',
+		'site',
+		'blog'
+	],
+	#category : #'Foliage-Core-Tests'
+}
+
+{ #category : #running }
+FOSeriesIndexBuilderTest >> setUp [
+	super setUp.
+	tempDir := FileLocator temp / ('fo-series-index-test-', UUID new asString36).
+	tempDir ensureCreateDirectory.
+	(tempDir / 'templates') ensureCreateDirectory.
+	(tempDir / 'templates' / 'blog') writeStreamDo: [ :s |
+		s nextPutAll: '<html><title>{{page.title}}</title>{{{ body }}}</html>' ].
+	(tempDir / 'templates' / 'blog-post-abstract') writeStreamDo: [ :s |
+		s nextPutAll: '<article>{{abstract}}</article>' ].
+	(tempDir / 'templates' / 'blog-post') writeStreamDo: [ :s |
+		s nextPutAll: '<html><title>{{page.title}}</title>{{{ body }}}</html>' ].
+	(tempDir / 'templates' / 'series-abstract') writeStreamDo: [ :s |
+		s nextPutAll: '<section><a href="{{pathString}}">{{title}}</a> ({{partCount}} parts): {{abstract}}</section>' ].
+	site := FOWebSite new
+		targetPath: (tempDir / 'docs');
+		templatePath: (tempDir / 'templates');
+		yourself.
+	blog := FOBlog new title: 'My Blog'; yourself.
+	site root at: #blog put: blog
+]
+
+{ #category : #running }
+FOSeriesIndexBuilderTest >> tearDown [
+	tempDir ifNotNil: [ tempDir exists ifTrue: [ tempDir deleteAll ] ].
+	super tearDown
+]
+
+{ #category : #private }
+FOSeriesIndexBuilderTest >> makePostTitled: aTitle publishDate: aDateString series: aSlug [
+	| post |
+	post := FOFoliagePage new
+		meta: (Dictionary new
+			at: #title put: aTitle;
+			at: #publishDate put: aDateString;
+			yourself);
+		document: (FOMarkdownParser parse: aTitle, ' text.');
+		yourself.
+	post meta at: #series put: aSlug.
+	^ post
+]
+
+{ #category : #tests }
+FOSeriesIndexBuilderTest >> testSeriesRenderAbstractUsesTheSeriesAbstractTemplate [
+	| aSeries |
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	blog at: #part2 put: (self makePostTitled: 'Part 2' publishDate: '2026-07-21' series: 'soil').
+	aSeries := blog series detect: [ :s | s slug = 'soil' ].
+	self assert: aSeries renderAbstract equals:
+		'<section><a href="/blog/series/soil.html">Soil</a> (2 parts): Part 1 text.</section>'
+]
+
+{ #category : #tests }
+FOSeriesIndexBuilderTest >> testBuildPageListsEverySeriesNewestActiveFirst [
+	| builder page stream |
+	blog at: #soilOld put: (self makePostTitled: 'Soil old' publishDate: '2020-01-01' series: 'soil').
+	blog at: #byobNew put: (self makePostTitled: 'Byob new' publishDate: '2026-07-01' series: 'byob').
+	builder := FOSeriesIndexBuilder new blog: blog; yourself.
+	page := builder buildPage.
+	self assert: page title equals: 'Series'.
+	stream := WriteStream on: String new.
+	page renderOn: stream.
+	self assert: stream contents equals:
+		'<section><a href="/blog/series/byob.html">Byob</a> (1 parts): Byob new text.</section>',
+		'<section><a href="/blog/series/soil.html">Soil</a> (1 parts): Soil old text.</section>'
+]

--- a/src/Foliage-Core/FOBlog.class.st
+++ b/src/Foliage-Core/FOBlog.class.st
@@ -94,12 +94,18 @@ FOBlog >> publishedPosts [
 { #category : #series }
 FOBlog >> series [
 	"One FOSeries per distinct 'series' slug found among published posts,
-	alphabetically by slug for deterministic output ordering."
-	^ self seriesSlugs asSortedCollection asArray collect: [ :slug |
+	newest-active-first: sorted by each series' most recent post (posts are
+	stored reading-order-ascending, so that's simply the last one) -
+	matches the blog overview's own newest-first convention, which is the
+	common way other blogs/SSGs order a listing of multiple series."
+	| unsorted |
+	unsorted := self seriesSlugs asSortedCollection asArray collect: [ :slug |
 		FOSeries new
 			slug: slug;
 			posts: (self postsInSeries: slug);
-			yourself ]
+			blog: self;
+			yourself ].
+	^ unsorted asSortedCollection: [ :a :b | a posts last publishDate > b posts last publishDate ]
 ]
 
 { #category : #series }

--- a/src/Foliage-Core/FOSeries.class.st
+++ b/src/Foliage-Core/FOSeries.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'slug',
-		'posts'
+		'posts',
+		'blog'
 	],
 	#category : #'Foliage-Core-Blog'
 }
@@ -18,6 +19,34 @@ FOSeries class >> titleFromSlug: aSlug [
 			s nextPutAll: word first asUppercase asString.
 			word size > 1 ifTrue: [ s nextPutAll: (word copyFrom: 2 to: word size) ] ]
 		separatedBy: [ s nextPut: $  ] ]
+]
+
+{ #category : #accessing }
+FOSeries >> abstract [
+	"Reuses the first (oldest, i.e. reading-order-first) post's own already-
+	truncated abstract - same zero-config reasoning as titleFromSlug:, no
+	separate series-description field/registry needed yet."
+	^ self posts first abstract
+]
+
+{ #category : #accessing }
+FOSeries >> blog [
+	^ blog
+]
+
+{ #category : #accessing }
+FOSeries >> blog: aFOBlog [
+	blog := aFOBlog
+]
+
+{ #category : #accessing }
+FOSeries >> partCount [
+	^ self posts size
+]
+
+{ #category : #accessing }
+FOSeries >> pathString [
+	^ blog pathString, '/series/', slug, '.html'
 ]
 
 { #category : #accessing }
@@ -43,4 +72,25 @@ FOSeries >> slug: aString [
 { #category : #accessing }
 FOSeries >> title [
 	^ self class titleFromSlug: slug
+]
+
+{ #category : #accessing }
+FOSeries >> website [
+	^ blog website
+]
+
+{ #category : #accessing }
+FOSeries >> abstractLayout [
+	^ 'series-abstract'
+]
+
+{ #category : #accessing }
+FOSeries >> abstractTemplate [
+	^ (self website templatePathForLayout: self abstractLayout) asMustacheTemplate
+]
+
+{ #category : #rendering }
+FOSeries >> renderAbstract [
+	^ (FOSeriesRenderContext new website: self website; series: self; yourself)
+		renderTemplate: self abstractTemplate
 ]

--- a/src/Foliage-Core/FOSeriesIndexBuilder.class.st
+++ b/src/Foliage-Core/FOSeriesIndexBuilder.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #FOSeriesIndexBuilder,
+	#superclass : #Object,
+	#instVars : [
+		'blog'
+	],
+	#category : #'Foliage-Core-Blog'
+}
+
+{ #category : #accessing }
+FOSeriesIndexBuilder >> blog: aBlog [
+	blog := aBlog
+]
+
+{ #category : #building }
+FOSeriesIndexBuilder >> buildPage [
+	"One entry per series, each rendered through the 'series-abstract'
+	template via FOSeries>>renderAbstract (title/pathString/abstract/
+	partCount) - same bodyHtml/outer-template approach as
+	FOBlogOverviewBuilder/FOSeriesOverviewBuilder, listing blog series
+	(newest-active-first, see FOBlog>>series) instead of individual posts."
+	| html |
+	html := String streamContents: [ :s |
+		blog series do: [ :aSeries | s nextPutAll: aSeries renderAbstract ] ].
+	^ FOFoliagePage new
+		parent: blog parent;
+		title: 'Series';
+		layout: blog layout;
+		bodyHtml: html;
+		yourself
+]

--- a/src/Foliage-Core/FOSeriesRenderContext.class.st
+++ b/src/Foliage-Core/FOSeriesRenderContext.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : #FOSeriesRenderContext,
+	#superclass : #FORenderContext,
+	#instVars : [
+		'series'
+	],
+	#category : #'Foliage-Core-Blog'
+}
+
+{ #category : #accessing }
+FOSeriesRenderContext >> abstract [
+	^ series abstract
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> layout [
+	^ series abstractLayout
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> partCount [
+	^ series partCount
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> pathString [
+	^ series pathString
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> series [
+	^ series
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> series: aFOSeries [
+	series := aFOSeries
+]
+
+{ #category : #accessing }
+FOSeriesRenderContext >> title [
+	^ series title
+]

--- a/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOPublisherTest.class.st
@@ -27,6 +27,8 @@ FOPublisherTest >> setUp [
 		s nextPutAll: '<html><title>{{page.title}}</title>{{{ body }}}</html>' ].
 	(tempDir / 'source' / 'templates' / 'blog-post-abstract') writeStreamDo: [ :s |
 		s nextPutAll: '<article>{{abstract}}</article>' ].
+	(tempDir / 'source' / 'templates' / 'series-abstract') writeStreamDo: [ :s |
+		s nextPutAll: '<section><a href="{{pathString}}">{{title}}</a>: {{abstract}}</section>' ].
 	(tempDir / 'source' / 'templates' / 'rss.xml') writeStreamDo: [ :s |
 		s nextPutAll: '<rss>{{# channels }}<channel>{{# items }}<item><title>{{title}}</title></item>{{/ items }}</channel>{{/ channels }}</rss>' ].
 	publisher := FOPublisher new
@@ -104,7 +106,10 @@ FOPublisherTest >> testPublishGeneratesSeriesOverviewPage [
 	self assert: (html includesSubstring: 'Soil part 1 text.').
 	self assert: (html includesSubstring: 'Soil part 2 text.').
 	self assert: (html indexOfSubCollection: 'Soil part 1 text.') <
-		(html indexOfSubCollection: 'Soil part 2 text.')
+		(html indexOfSubCollection: 'Soil part 2 text.').
+	self assert: (tempDir / 'generated' / 'blog' / 'series' / 'index.html') exists.
+	self assert: ((tempDir / 'generated' / 'blog' / 'series' / 'index.html') contents
+		includesSubstring: '<a href="/blog/series/soil.html">Soil</a>')
 ]
 
 { #category : #tests }

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -94,6 +94,7 @@ FOPublisher >> publish [
 		blog at: #'rss.xml' put: blog rssFeed.
 		blog series ifNotEmpty: [
 			seriesFolder := blog resolvePath: (RelativePath from: 'series').
+			seriesFolder at: #'index.html' put: (FOSeriesIndexBuilder new blog: blog; buildPage).
 			blog series do: [ :aSeries |
 				seriesFolder
 					at: (aSeries slug, '.html') asSymbol


### PR DESCRIPTION
Per feedback on the initial series feature: series entries should render through a real template (like blog-post-abstract does for posts) instead of hardcoded Smalltalk HTML, and multiple series in a listing should sort by recency rather than alphabetically, matching how the blog overview itself already orders posts.

- FOSeries gained website/abstractLayout/abstractTemplate/renderAbstract, mirroring FOBlogPost's own abstract-rendering shape - renders through a new 'series-abstract' template (companion change in noha.github.io) via the new FOSeriesRenderContext (title/pathString/abstract/partCount).
- FOSeries>>abstract reuses the first (reading-order) post's own already- truncated abstract text - same zero-config reasoning as titleFromSlug:.
- FOBlog>>series now sorts by each series' most recent post's publishDate descending (posts are stored reading-order-ascending, so that's simply the last one), not alphabetically by slug - alphabetical was only ever meant for deterministic per-series-file generation, not as a real reading order for a listing of multiple series.
- FOSeriesIndexBuilder builds one page concatenating every series' rendered abstract, same bodyHtml/outer-template approach as FOBlogOverviewBuilder/FOSeriesOverviewBuilder.
- FOPublisher>>publish inserts it at blog/series/index.html, alongside the existing per-series overview pages.

Verified against the real noha.github.io content: blog/series/index.html lists the "soil" series with the correct link, first-post abstract, and part count. Multi-series ordering (recency, not alphabetical) is only exercised by synthetic tests so far, since real content currently has just one series.