### PR TITLE
Rename rawPath to contentPath, add dataPath, support series abstract …

### DIFF
--- a/src/Foliage-Core-Tests/FOImporterTest.class.st
+++ b/src/Foliage-Core-Tests/FOImporterTest.class.st
@@ -15,7 +15,7 @@ FOImporterTest >> setUp [
 	tempDir := FileLocator temp / ('fo-importer-test-', UUID new asString36).
 	tempDir ensureCreateDirectory.
 	website := FOTestWebsite new
-		rawPath: tempDir;
+		contentPath: tempDir;
 		targetPath: (tempDir / 'docs');
 		yourself.
 	website root: (FOWebsiteRoot new parent: website; yourself).

--- a/src/Foliage-Core-Tests/FOSeriesIndexBuilderTest.class.st
+++ b/src/Foliage-Core-Tests/FOSeriesIndexBuilderTest.class.st
@@ -62,6 +62,27 @@ FOSeriesIndexBuilderTest >> testSeriesRenderAbstractUsesTheSeriesAbstractTemplat
 ]
 
 { #category : #tests }
+FOSeriesIndexBuilderTest >> testAbstractPrefersHandWrittenDataFileOverAutoDerivedOne [
+	| aSeries |
+	site dataPath: (tempDir / 'data').
+	(tempDir / 'data' / 'series') ensureCreateDirectory.
+	(tempDir / 'data' / 'series' / 'soil.md') writeStreamDo: [ :s |
+		s nextPutAll: 'A hand-written description of the whole series.' ].
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	aSeries := blog series detect: [ :s | s slug = 'soil' ].
+	self assert: aSeries abstract equals: 'A hand-written description of the whole series.'
+]
+
+{ #category : #tests }
+FOSeriesIndexBuilderTest >> testAbstractFallsBackToFirstPostWhenNoDataFileExists [
+	| aSeries |
+	site dataPath: (tempDir / 'data').
+	blog at: #part1 put: (self makePostTitled: 'Part 1' publishDate: '2026-07-20' series: 'soil').
+	aSeries := blog series detect: [ :s | s slug = 'soil' ].
+	self assert: aSeries abstract equals: 'Part 1 text.'
+]
+
+{ #category : #tests }
 FOSeriesIndexBuilderTest >> testBuildPageListsEverySeriesNewestActiveFirst [
 	| builder page stream |
 	blog at: #soilOld put: (self makePostTitled: 'Soil old' publishDate: '2020-01-01' series: 'soil').

--- a/src/Foliage-Core-Tests/FOTestWebsite.class.st
+++ b/src/Foliage-Core-Tests/FOTestWebsite.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'targetPath',
-		'rawPath',
+		'contentPath',
 		'root',
 		'templatePath',
 		'blogPaths'
@@ -22,13 +22,13 @@ FOTestWebsite >> targetPath: aFileReference [
 ]
 
 { #category : #accessing }
-FOTestWebsite >> rawPath [
-	^ rawPath
+FOTestWebsite >> contentPath [
+	^ contentPath
 ]
 
 { #category : #accessing }
-FOTestWebsite >> rawPath: aFileReference [
-	rawPath := aFileReference
+FOTestWebsite >> contentPath: aFileReference [
+	contentPath := aFileReference
 ]
 
 { #category : #accessing }
@@ -47,8 +47,8 @@ FOTestWebsite >> resolvePath: aPath [
 ]
 
 { #category : #accessing }
-FOTestWebsite >> relativeRawPath: aFileReference [
-	^ aFileReference asAbsolute relativeTo: self rawPath asAbsolute
+FOTestWebsite >> relativeContentPath: aFileReference [
+	^ aFileReference asAbsolute relativeTo: self contentPath asAbsolute
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Core-Tests/FOWebResourceModelTest.class.st
+++ b/src/Foliage-Core-Tests/FOWebResourceModelTest.class.st
@@ -49,7 +49,7 @@ FOWebResourceModelTest >> testPathComputation [
 ]
 
 { #category : #tests }
-FOWebResourceModelTest >> testPublishPathMirrorsRawPathByDefault [
+FOWebResourceModelTest >> testPublishPathMirrorsContentPathByDefault [
 	| blog post |
 	blog := FOWebFolder new.
 	root at: #blog put: blog.

--- a/src/Foliage-Core-Tests/FOWebSiteTest.class.st
+++ b/src/Foliage-Core-Tests/FOWebSiteTest.class.st
@@ -8,19 +8,20 @@ Class {
 FOWebSiteTest >> testDefaultPaths [
 	| site |
 	site := FOWebSite new.
-	self assert: site rawPath asString equals: 'raw' asFileReference asString.
+	self assert: site contentPath asString equals: 'content' asFileReference asString.
 	self assert: site targetPath asString equals: 'docs' asFileReference asString.
-	self assert: site templatePath asString equals: 'templates' asFileReference asString
+	self assert: site templatePath asString equals: 'templates' asFileReference asString.
+	self assert: site dataPath asString equals: 'data' asFileReference asString
 ]
 
 { #category : #tests }
 FOWebSiteTest >> testExplicitPathsOverrideDefaults [
 	| site |
 	site := FOWebSite new
-		rawPath: '/tmp/raw';
+		contentPath: '/tmp/content';
 		targetPath: '/tmp/docs' asFileReference;
 		yourself.
-	self assert: site rawPath asString equals: '/tmp/raw' asFileReference asString.
+	self assert: site contentPath asString equals: '/tmp/content' asFileReference asString.
 	self assert: site targetPath asString equals: '/tmp/docs' asFileReference asString
 ]
 
@@ -59,7 +60,7 @@ FOWebSiteTest >> testImportBuildsRealTreeFromDisk [
 		(tempDir / 'images') ensureCreateDirectory.
 		((tempDir / 'images') / 'logo.png') writeStreamDo: [ :s | s nextPutAll: 'fake png' ].
 		site := FOWebSite new
-			rawPath: tempDir;
+			contentPath: tempDir;
 			targetPath: (tempDir / 'docs');
 			yourself.
 		site import.

--- a/src/Foliage-Core/FOImporter.class.st
+++ b/src/Foliage-Core/FOImporter.class.st
@@ -23,7 +23,7 @@ FOImporter >> readAll: files [
 FOImporter >> readFile: file [
 	self
 		readFile: file
-		path: (website relativeRawPath: file)
+		path: (website relativeContentPath: file)
 ]
 
 { #category : #generation }

--- a/src/Foliage-Core/FOSeries.class.st
+++ b/src/Foliage-Core/FOSeries.class.st
@@ -23,10 +23,31 @@ FOSeries class >> titleFromSlug: aSlug [
 
 { #category : #accessing }
 FOSeries >> abstract [
-	"Reuses the first (oldest, i.e. reading-order-first) post's own already-
-	truncated abstract - same zero-config reasoning as titleFromSlug:, no
-	separate series-description field/registry needed yet."
-	^ self posts first abstract
+	"A hand-written data/series/<slug>.md overrides the auto-derived
+	abstract, if present - read directly from disk (frontmatter + body,
+	same parsers as any other content file) rather than through the normal
+	FOImporter/site-tree mechanism, since this file must never become a
+	published page of its own (it would collide with the auto-generated
+	overview page at the same slug). Falls back to the first (oldest, i.e.
+	reading-order-first) post's own already-truncated abstract when no such
+	file exists - same zero-config reasoning as titleFromSlug:."
+	| dataFile |
+	dataFile := self dataAbstractFile.
+	^ dataFile exists
+		ifTrue: [ self renderDataAbstract: dataFile ]
+		ifFalse: [ self posts first abstract ]
+]
+
+{ #category : #accessing }
+FOSeries >> dataAbstractFile [
+	^ (self website dataPath / 'series' / (slug, '.md')) asFileReference
+]
+
+{ #category : #accessing }
+FOSeries >> renderDataAbstract: aFileReference [
+	| frontmatter |
+	frontmatter := FOFrontmatterParser parse: aFileReference contents.
+	^ FOPlainTextVisitor render: (FOMarkdownParser parse: frontmatter body)
 ]
 
 { #category : #accessing }

--- a/src/Foliage-Core/FOWebResource.class.st
+++ b/src/Foliage-Core/FOWebResource.class.st
@@ -46,7 +46,7 @@ FOWebResource >> relativePath [
 
 { #category : #accessing }
 FOWebResource >> publishPath [
-	"Mirrors rawPath 1:1 by default (raw/foo.md -> docs/foo.html); pages that
+	"Mirrors contentPath 1:1 by default (content/foo.md -> docs/foo.html); pages that
 	need a different output path (e.g. a generated blog overview page) override
 	this."
 	^ self website targetPath resolvePath: self relativePath

--- a/src/Foliage-Core/FOWebSite.class.st
+++ b/src/Foliage-Core/FOWebSite.class.st
@@ -5,7 +5,8 @@ Class {
 		'baseUri',
 		'targetPath',
 		'templatePath',
-		'rawPath',
+		'contentPath',
+		'dataPath',
 		'root',
 		'properties',
 		'blogPaths'
@@ -42,9 +43,9 @@ FOWebSite >> baseUri: anObject [
 FOWebSite >> blogPaths [
 	"Top-level (direct child of root) folder names that should become FOBlog
 	instead of a plain FOWebFolder as soon as the import creates them.
-	Same ivar-with-overridable-default pattern as rawPath/targetPath/
+	Same ivar-with-overridable-default pattern as contentPath/targetPath/
 	templatePath: a subclass can override defaultBlogPaths (like
-	NohaWebsite overrides defaultRawPath) for a compile-time declaration, or
+	NohaWebsite overrides defaultContentPath) for a compile-time declaration, or
 	a caller can set blogPaths: at runtime (e.g. FOPublisher, driven by a
 	per-invocation .foliage.ston project file) - either way works. Replaces
 	the old post-hoc FOWebFolder>>convertToBlog object surgery."
@@ -68,8 +69,13 @@ FOWebSite >> buildRoot [
 ]
 
 { #category : #accessing }
-FOWebSite >> defaultRawPath [
-	^ 'raw'
+FOWebSite >> defaultContentPath [
+	^ 'content'
+]
+
+{ #category : #accessing }
+FOWebSite >> defaultDataPath [
+	^ 'data'
 ]
 
 { #category : #accessing }
@@ -84,7 +90,7 @@ FOWebSite >> defaultTemplatePath [
 
 { #category : #building }
 FOWebSite >> import [
-	self importDirectory: self rawPath
+	self importDirectory: self contentPath
 ]
 
 { #category : #building }
@@ -130,18 +136,28 @@ FOWebSite >> publish [
 ]
 
 { #category : #accessing }
-FOWebSite >> rawPath [
-	^ rawPath ifNil: [ rawPath := self defaultRawPath asFileReference ]
+FOWebSite >> contentPath [
+	^ contentPath ifNil: [ contentPath := self defaultContentPath asFileReference ]
 ]
 
 { #category : #accessing }
-FOWebSite >> rawPath: anObject [
-	rawPath := anObject asFileReference
+FOWebSite >> contentPath: anObject [
+	contentPath := anObject asFileReference
 ]
 
 { #category : #accessing }
-FOWebSite >> relativeRawPath: aFileReference [
-	^ aFileReference asAbsolute relativeTo: self rawPath asAbsolute
+FOWebSite >> dataPath [
+	^ dataPath ifNil: [ dataPath := self defaultDataPath asFileReference ]
+]
+
+{ #category : #accessing }
+FOWebSite >> dataPath: anObject [
+	dataPath := anObject asFileReference
+]
+
+{ #category : #accessing }
+FOWebSite >> relativeContentPath: aFileReference [
+	^ aFileReference asAbsolute relativeTo: self contentPath asAbsolute
 ]
 
 { #category : #navigating }

--- a/src/Foliage-Publisher-Tests/FOSiteIntegrationTest.class.st
+++ b/src/Foliage-Publisher-Tests/FOSiteIntegrationTest.class.st
@@ -15,8 +15,8 @@ FOSiteIntegrationTest >> nl [
 
 { #category : #private }
 FOSiteIntegrationTest >> writeFile: aRelativeName contents: aString [
-	"FOPublisher>>publish uses sourcePath directly as rawPath (no further
-	'raw' subfolder), so content files live straight under tempDir/source."
+	"FOPublisher>>publish uses sourcePath directly as contentPath (no further
+	'content' subfolder), so content files live straight under tempDir/source."
 	| file |
 	file := tempDir / 'source' / aRelativeName.
 	file parent ensureCreateDirectory.

--- a/src/Foliage-Publisher/FOPublisher.class.st
+++ b/src/Foliage-Publisher/FOPublisher.class.st
@@ -6,6 +6,7 @@ Class {
 		'targetPath',
 		'sourcePath',
 		'templatePath',
+		'dataPath',
 		'blogs'
 	],
 	#category : #'Foliage-Publisher'
@@ -29,6 +30,11 @@ FOPublisher class >> defaultTargetPath [
 { #category : #defaults }
 FOPublisher class >> defaultTemplatePath [
 	^ 'templates'
+]
+
+{ #category : #defaults }
+FOPublisher class >> defaultDataPath [
+	^ 'data'
 ]
 
 { #category : #'instance creation' }
@@ -79,11 +85,12 @@ FOPublisher >> publish [
 	site := FOWebSite new
 		baseUri: self baseUri;
 		targetPath: self targetPath asFileReference;
-		rawPath: self sourcePath asFileReference;
+		contentPath: self sourcePath asFileReference;
 		templatePath: self sourcePath asFileReference / self templatePath;
+		dataPath: self sourcePath asFileReference / self dataPath;
 		blogPaths: (self blogs collect: [ :assoc | assoc key asString ]);
 		yourself.
-	allFiles := site rawPath allFiles.
+	allFiles := site contentPath allFiles.
 	site importer readAll: allFiles.
 	self blogs do: [ :assoc |
 		| blog seriesFolder |
@@ -130,4 +137,14 @@ FOPublisher >> templatePath [
 { #category : #accessing }
 FOPublisher >> templatePath: aString [
 	templatePath := aString
+]
+
+{ #category : #accessing }
+FOPublisher >> dataPath [
+	^ dataPath ifNil: [ dataPath := self class defaultDataPath ]
+]
+
+{ #category : #accessing }
+FOPublisher >> dataPath: aString [
+	dataPath := aString
 ]


### PR DESCRIPTION
…override

Part of a broader site-layout rework Norbert wants (content/ vs data/ vs static/, discussed in chat): content/ is everything that lands in the target dir (processed or verbatim-copied), data/ is files Foliage needs while building that never become their own published page. static/ is deliberately NOT part of this change - still under discussion, not decided yet.

- FOWebSite: rawPath/rawPath:/defaultRawPath/relativeRawPath: renamed to contentPath/contentPath:/defaultContentPath/relativeContentPath: (default 'content' instead of 'raw'). New dataPath/dataPath:/defaultDataPath (default 'data'), same ivar-with-overridable-default shape as the other paths.
- FOPublisher: gained a matching dataPath/dataPath: (default 'data'), nested under sourcePath the same way templatePath already is; passes both through in publish.
- FOImporter/FOWebResource: updated to the renamed API (relativeContentPath:, comment wording).
- FOSeries>>abstract: now checks data/series/<slug>.md first (frontmatter
  + body, read directly from disk via FOFrontmatterParser/FOMarkdownParser
  - deliberately NOT through FOImporter/the site tree, since a page at that exact slug would collide with the auto-generated series overview page) and falls back to the first post's own abstract when no such file exists. Body only, no frontmatter fields read from it yet (e.g. a title override) - not asked for, matches the file's whole purpose today (a hand-written abstract, nothing else).

Verified: full suite green (Foliage-Core-Tests, Foliage-Publisher-Tests, Foliage-Markdown-Tests, Foliage-Frontmatter-Tests), plus a real dry run against noha.github.io's renamed content/ tree (companion change in that repo) - import + full publish, including series pages, completes with no errors and the same output as before the rename.