### PR TITLE
Rename FOWebSite's default target folder from docs to output

### DIFF
--- a/src/Foliage-Core-Tests/FOWebSiteTest.class.st
+++ b/src/Foliage-Core-Tests/FOWebSiteTest.class.st
@@ -9,7 +9,7 @@ FOWebSiteTest >> testDefaultPaths [
 	| site |
 	site := FOWebSite new.
 	self assert: site contentPath asString equals: 'content' asFileReference asString.
-	self assert: site targetPath asString equals: 'docs' asFileReference asString.
+	self assert: site targetPath asString equals: 'output' asFileReference asString.
 	self assert: site templatePath asString equals: 'templates' asFileReference asString.
 	self assert: site dataPath asString equals: 'data' asFileReference asString
 ]

--- a/src/Foliage-Core/FOWebResource.class.st
+++ b/src/Foliage-Core/FOWebResource.class.st
@@ -46,7 +46,7 @@ FOWebResource >> relativePath [
 
 { #category : #accessing }
 FOWebResource >> publishPath [
-	"Mirrors contentPath 1:1 by default (content/foo.md -> docs/foo.html); pages that
+	"Mirrors contentPath 1:1 by default (content/foo.md -> output/foo.html); pages that
 	need a different output path (e.g. a generated blog overview page) override
 	this."
 	^ self website targetPath resolvePath: self relativePath

--- a/src/Foliage-Core/FOWebSite.class.st
+++ b/src/Foliage-Core/FOWebSite.class.st
@@ -80,7 +80,7 @@ FOWebSite >> defaultDataPath [
 
 { #category : #accessing }
 FOWebSite >> defaultTargetPath [
-	^ 'docs'
+	^ 'output'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Companion to the content/data rename: FOWebSite>>defaultTargetPath was still 'docs', left over from the old naming. FOPublisher's own separate defaultTargetPath ('generated') is untouched - a different, independent default not part of what was actually asked (renaming the site's real output folder, docs/, to output/).

Only FOWebSiteTest>>testDefaultPaths needed updating (it asserts the actual default value) - the many other tests using 'docs' as their own temp-fixture output folder name are unaffected, since they set targetPath explicitly regardless of what the default is.